### PR TITLE
Docker

### DIFF
--- a/Dockerfile.bedrock
+++ b/Dockerfile.bedrock
@@ -1,0 +1,3 @@
+FROM ejaxonavl/devmachine
+RUN conda create -n bedrock python=3.9
+RUN echo "conda activate bedrock" >> ~/.bashrc

--- a/Dockerfile.devmachine
+++ b/Dockerfile.devmachine
@@ -1,0 +1,11 @@
+FROM amazonlinux:2
+RUN yum -y update
+RUN mkdir /home/bedrock
+RUN yum install -y gcc-c++ make
+RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
+RUN yum -y install nodejs git unzip
+RUN cd /tmp; curl "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" -o miniconda3.sh; \
+   bash ./miniconda3.sh -b -p /usr/share/miniconda; rm ./miniconda3.sh; ln -s /usr/share/miniconda/bin/conda /usr/local/bin/conda
+RUN cd /tmp; curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+   unzip awscliv2.zip; ./aws/install; rm -Rf aws awscliv2.zip
+

--- a/Dockerfile.devmachine
+++ b/Dockerfile.devmachine
@@ -6,6 +6,7 @@ RUN curl -sL https://rpm.nodesource.com/setup_12.x | bash -
 RUN yum -y install nodejs git unzip
 RUN cd /tmp; curl "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh" -o miniconda3.sh; \
    bash ./miniconda3.sh -b -p /usr/share/miniconda; rm ./miniconda3.sh; ln -s /usr/share/miniconda/bin/conda /usr/local/bin/conda
+RUN conda init bash
 RUN cd /tmp; curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
    unzip awscliv2.zip; ./aws/install; rm -Rf aws awscliv2.zip
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,20 @@
 
 Second version of the Bedrock system.
 
+cd /home/bedrock
+conda create -n bedrock python=3.9
+conda activate bedrock
+pip install requirements.txt
+python setup.py develop
+
 ## Using the Docker Development Machine
 docker build -f Dockerfile.devmachine --tag ejaxonavl/devmachine .
-winpty docker run -it -v "C:\Users\ericjackson\dev\docker":/home/bedrock ejaxonavl/devmachine sh
+docker build -f Dockerfile.bedrock --tag ejaxonavl/bedrock .
+
+### To log in
+winpty docker run -it -v "C:\Users\ericjackson\dev\bedrock\bedrock2":/home/bedrock ejaxonavl/bedrock bash
+
+### Other useful commands
 docker images
 docker ps -a
 docker image prune

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Bedrock 2
 
 Second version of the Bedrock system.
+
+## Using the Docker Development Machine
+docker build -f Dockerfile.devmachine --tag ejaxonavl/devmachine .
+winpty docker run -it -v "C:\Users\ericjackson\dev\docker":/home/bedrock ejaxonavl/devmachine sh
+docker images
+docker ps -a
+docker image prune
+docker container prune

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ cement==3.0.2
 jinja2
 pyyaml
 colorlog
+boto3
+


### PR DESCRIPTION
I've created two Dockerfiles, one to create a base development machine (Dockerfile.devmachine) and one very minimal one that creates a bedrock conda environment and activates it as part of bash startup.

I also added boto3 to the requirements.txt file.

The only other change is to the README where I'm starting to gather information to write the documentation.

If I create the images and create a container to run it with the bedrock2 source directory mounted at /home/bedrock (see the README for sample docker commands to do that in Windows), then I can log into the docker container and run:

    cd /home/bedrock
    pip install -r requirements.txt
    python setup.py develop

That's enough for bedrock to run. Obviously still need to work on instructions for building the actual AWS part.

   