### PR TITLE
Fix error print

### DIFF
--- a/bedrock/aws/lambda_functions/etl_task_table_copy/createGoogleWritable.js
+++ b/bedrock/aws/lambda_functions/etl_task_table_copy/createGoogleWritable.js
@@ -36,7 +36,7 @@ async function writeToSheet (location, theData, append = false) {
       }
     })
   }catch(err){
-    console.error('Google error: ' + err, err.result.error.message);
+    console.error('Google error: ', err);
   }
 }
 


### PR DESCRIPTION
The error we see in the second stage of the abi_outreach_vendors run is actually an error in printing the original error. This just fixes the error print statement.
