### PR TITLE
Running from tables. Using cron_strings instead of rungroup param

### DIFF
--- a/src/etl/lambdas/create_etl_run_map/handler.js
+++ b/src/etl/lambdas/create_etl_run_map/handler.js
@@ -162,10 +162,10 @@ async function getRungroups(connection) {
         const minutes = TIME_INTERVAL;
         const ms = 1000 * 60 * minutes;
         const curTime = new Date();
-        const prevOccurenceMS = (awsCronParser.prev(cron, curTime)).getTime();
-        const nextOccurrenceMS = prevOccurenceMS + ms;
-
-        if (nextOccurrenceMS >= curTime.getTime()) {
+        const latestPreviousTimeMS = (awsCronParser.prev(cron, curTime)).getTime();
+        const endPreviousTimeSlot = latestPreviousTimeMS + ms;
+        // See if current time falls within TIME_INTERVAL following the latest run time
+        if (endPreviousTimeSlot >= curTime.getTime()) {
           rungroups.push(cname);
         }
       }

--- a/src/etl/lambdas/create_etl_run_map/test/TestingCronStrings.js
+++ b/src/etl/lambdas/create_etl_run_map/test/TestingCronStrings.js
@@ -20,13 +20,13 @@ for (let i = 0; i < 5; i += 1) {
     const minutes = TIME_INTERVAL;
     const ms = 1000 * 60 * minutes;
     // const curTime = new Date();
-    const prevOccurenceMS = (awsCronParser.prev(cron, curTime)).getTime();
-    const nextOccurrenceMS = prevOccurenceMS + ms;
-
-    if (nextOccurrenceMS >= curTime.getTime()) {
-      console.log('yes', cstring, new Date(prevOccurenceMS).toLocaleString(), curTime.toLocaleString(), new Date(nextOccurrenceMS).toLocaleString());
+    const latestPreviousTimeMS = (awsCronParser.prev(cron, curTime)).getTime();
+    const endPreviousTimeSlot = latestPreviousTimeMS + ms;
+    // See if current time falls within TIME_INTERVAL following the latest run time
+    if (endPreviousTimeSlot >= curTime.getTime()) {
+      console.log('yes', cstring, new Date(latestPreviousTimeMS).toLocaleString(), curTime.toLocaleString(), new Date(endPreviousTimeSlot).toLocaleString());
     } else {
-      console.log('no-', cstring, new Date(prevOccurenceMS).toLocaleString(), curTime.toLocaleString(), new Date(nextOccurrenceMS).toLocaleString());
+      console.log('no-', cstring, new Date(latestPreviousTimeMS).toLocaleString(), curTime.toLocaleString(), new Date(endPreviousTimeSlot).toLocaleString());
     }
   });
   console.log('====================');

--- a/src/etl/lambdas/create_etl_run_map/test/TestingCronStrings.js
+++ b/src/etl/lambdas/create_etl_run_map/test/TestingCronStrings.js
@@ -1,0 +1,87 @@
+/* eslint-disable no-console */
+// Testing random times with cron logic
+
+const awsCronParser = require('aws-cron-parser');
+
+const TIME_INTERVAL = 15; // Frequency - must match Eventbridge scheduler
+
+function randomDate(start, end) {
+  return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+}
+
+// deployed version
+for (let i = 0; i < 5; i += 1) {
+  let curTime;
+  if (i === 0) curTime = new Date(2023, 1, 7, 11, 15, 0, 0); // test if exactly on 1/4 hr
+  else curTime = randomDate(new Date(2023, 1, 7), new Date(2023, 1, 8));
+  const cstringArr = ['00 * * * ? *', '15 * * * ? *', '30 * * * ? *', '45 * * * ? *'];
+  cstringArr.forEach((cstring) => {
+    const cron = awsCronParser.parse(cstring);
+    const minutes = TIME_INTERVAL;
+    const ms = 1000 * 60 * minutes;
+    // const curTime = new Date();
+    const prevOccurenceMS = (awsCronParser.prev(cron, curTime)).getTime();
+    const nextOccurrenceMS = prevOccurenceMS + ms;
+
+    if (nextOccurrenceMS >= curTime.getTime()) {
+      console.log('yes', cstring, new Date(prevOccurenceMS).toLocaleString(), curTime.toLocaleString(), new Date(nextOccurrenceMS).toLocaleString());
+    } else {
+      console.log('no-', cstring, new Date(prevOccurenceMS).toLocaleString(), curTime.toLocaleString(), new Date(nextOccurrenceMS).toLocaleString());
+    }
+  });
+  console.log('====================');
+}
+
+// myDate.getTime() => myepoch
+// new Date(myepoch) => myDate
+
+// previous version - not correct
+for (let i = 0; i < 5; i += 1) {
+  let testTime;
+  if (i === 0) testTime = new Date(2023, 1, 7, 11, 15, 0, 0); // test if exactly on 1/4 hr
+  else testTime = randomDate(new Date(2023, 1, 7), new Date(2023, 1, 8));
+  const cstringArr = ['00 * * * ? *', '15 * * * ? *', '30 * * * ? *', '45 * * * ? *'];
+  cstringArr.forEach((cstring) => {
+    const cron = awsCronParser.parse(cstring);
+    const minutes = TIME_INTERVAL;
+    const ms = 1000 * 60 * minutes;
+    const curTime = new Date(Math.round(testTime.getTime() / ms) * ms);
+    const nextTime = new Date(curTime);
+    const delta = minutes * 60 * 1000;
+    nextTime.setTime(nextTime.getTime() + delta);
+    const occurrence = awsCronParser.next(cron, curTime);
+    if (occurrence.getTime() < nextTime.getTime()) {
+      console.log('yes', cstring, curTime.toLocaleString());
+    } else {
+      console.log('no-', cstring, curTime.toLocaleString());
+    }
+  });
+  console.log('====================');
+}
+
+// FAILED ATTEMPT TO ROUND
+// function timestr(date) {
+//   const str = date.toLocaleString();
+//   return ` - ${str.substring(str.indexOf(' ') + 1)}`;
+// }
+// for (let i = 0; i < 6; i += 1) {
+//   const testtime = randomDate(new Date(2023, 1, 7), new Date(2023, 1, 8));
+//   const cstringArr = ['00 * * * ? *', '15 * * * ? *', '30 * * * ? *', '45 * * * ? *'];
+//   cstringArr.forEach((cstring) => {
+//     const cron = awsCronParser.parse(cstring);
+//     const minutes = TIME_INTERVAL;
+//     const deltaMS = 1000 * 60 * minutes;
+//     const minusHalfMS = testtime.getTime() - (deltaMS / 2.0);
+//     const minusHalfRounded = new Date(Math.round(minusHalfMS / deltaMS) * deltaMS);
+//     const nextOccurrence = (awsCronParser.next(cron, minusHalfRounded));
+//     const prevOccurence = new Date(nextOccurrence.getTime() - deltaMS);
+//     if (prevOccurence.getTime() <= testtime.getTime()) {
+//       console.log('yes', cstring, timestr(testtime), timestr(minusHalfRounded),
+//       timestr(nextOccurrence), timestr(prevOccurence));
+//     } else {
+//       console.log('nop', cstring, timestr(testtime), timestr(minusHalfRounded),
+//       timestr(nextOccurrence), timestr(prevOccurence));
+//     }
+//   });
+//   console.log('====================');
+// }

--- a/src/etl/lambdas/etl_email_results/sendEmails.js
+++ b/src/etl/lambdas/etl_email_results/sendEmails.js
@@ -5,15 +5,10 @@ const ses_sendemail = require('./ses_sendemail');
 const compiledFunction = pug.compileFile(path.join(__dirname, '/email.pug'));
 
 function sendEmails(results) {
-  let doSend = true;
-  let emailAddrs = JSON.parse(process.env.EMAIL_RECIPIENT_JSON);
-  let htmlEmail, emailSubject;
-  if (!results.failure || !results.success || !results.skipped) {
-    emailSubject = "ETL Jobs Status: No valid results"
-    htmlEmail = "No valid results. Invalid rungroup?"
-  } else {
-    const totalResults = results.failure.length + results.success.length + results.skipped.length;
-    if (totalResults > 0) {
+  const totalResults = results?.failure?.length + results?.success?.length + results?.skipped?.length;
+  if (totalResults > 0) {
+    let emailAddrs = JSON.parse(process.env.EMAIL_RECIPIENT_JSON);
+    let htmlEmail, emailSubject;
       results.failure = results.failure.map(res => res.name)
       results.failure.sort()
       results.success.sort()
@@ -27,13 +22,10 @@ function sendEmails(results) {
       let pugObj = {};
       pugObj.results = results;
       htmlEmail = compiledFunction(pugObj);
-    }
-    else {
-      doSend = false;
-    }
+      ses_sendemail(emailAddrs, htmlEmail, emailSubject);
+  }else{
+    console.log('No email sent')
   }
-
-  if (doSend) ses_sendemail(emailAddrs, htmlEmail, emailSubject);
 }
 
 module.exports = sendEmails;

--- a/src/etl/stepfunctions/process_etl_run_group/deploy/states.json
+++ b/src/etl/stepfunctions/process_etl_run_group/deploy/states.json
@@ -1,7 +1,25 @@
 {
   "Comment": "State machine to run a single ETL run group",
-  "StartAt": "Init",
+  "StartAt": "CheckForRunGroup",
   "States": {
+    "CheckForRunGroup": {
+      "Comment": "See if rungroup is set",
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.rungroup",
+          "IsPresent": true,
+          "Next": "Init"
+        }
+      ],
+      "Default": "AddRunGroupFlag"
+    },
+    "AddRunGroupFlag": {
+      "Type": "Pass",
+      "Result": "UseCronStrings",
+      "ResultPath": "$.rungroup",
+      "Next": "Init"
+    },
     "Init": {
       "Comment": "Initialize the run map.",
       "Type": "Task",


### PR DESCRIPTION
**create_etl_run_group
process_etl_run_group**
In the Step Function "Init" step, $.rungroup is a parameter, which was erroring when it was missing. There were several ways to handle this, but I got it working.
I added two more steps before Init that put in a default. The null default didn't work, so I decided to give it a value of "UseCronStrings" when we don't provide one.

**sendEmails**
Since we are now running the job every 15 minutes, we don't want to send a 'fail' email if there are no jobs. Also simplify the code with the new JS _optional chaining_ syntax.