### PR TITLE
Support environment override for BEDROCK_DB_HOST

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/deploy/config.tf
+++ b/src/api/lambdas/bedrock-api-backend/deploy/config.tf
@@ -20,6 +20,11 @@ resource "aws_lambda_function" "bedrock-api-backend-$$INSTANCE$$" {
       subnet_ids         = var.subnet_ids
       security_group_ids = var.security_group_ids
     }
+    environment {
+      variables = {
+        BEDROCK_DB_HOST = $$BEDROCK_DB_HOST$$
+      }
+    }
 }
 
 output "bedrock-api-backend_arn" {

--- a/src/api/lambdas/bedrock-api-backend/handler.js
+++ b/src/api/lambdas/bedrock-api-backend/handler.js
@@ -16,7 +16,9 @@ async function getConnectionObject() {
   });
 
   // If BEDROCK_DB_HOST is not in the environment, assume normal bedrock DB
-  if (!('BEDROCK_DB_HOST' in process.env)) {
+  if (!('BEDROCK_DB_HOST' in process.env)
+      || process.env.BEDROCK_DB_HOST === null
+      || process.env.BEDROCK_DB_HOST.trim().length === 0) {
     return getConnection('nopubrecdb1/bedrock/bedrock_user')
       .then(
         (cpValue) => {

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -5,5 +5,7 @@ account = 518970837364
 email_recipients = "['dummy@ashevillenc.gov']"
 build_mode = std # Set to sam to build using SAM
 
+BEDROCK_DB_HOST = ""
+
 reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
 

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -1,11 +1,11 @@
-INSTANCE = ejdev
+INSTANCE = <YOU MUST PICK A UNIQUE INSTANCE STRING LIKE ejtest>
 region = "us-east-1"
 statebucket = "avl-tfstate-store"
 account = 518970837364
 email_recipients = "['dummy@ashevillenc.gov']"
 build_mode = std # Set to sam to build using SAM
-
 BEDROCK_DB_HOST = ""
 
+# Do not edit or delete the next line
 reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
 


### PR DESCRIPTION
Added BEDROCK_DB_HOST to the make_variables file with a default value of the empty string (""). This allows us to switch to a test database for, e.g., development of the API post, put, and delete endpoints. 

Modified the test in the getConnectionObject function to test not just for whether the variable is in the environment (it is), but also whether it's null or empty, in which case the default DB connection in Secrets Manager is used.

As a separate task, this same change will need to be made for create_etl_run_map in the ETL system.
