### PR TITLE
Enable Bedrock DB to be overridden when set in make_variables.

### DIFF
--- a/src/etl/lambdas/create_etl_run_map/deploy/config.tf
+++ b/src/etl/lambdas/create_etl_run_map/deploy/config.tf
@@ -20,6 +20,11 @@ resource "aws_lambda_function" "create_etl_run_map-$$INSTANCE$$" {
       subnet_ids         = var.subnet_ids
       security_group_ids = var.security_group_ids
     }
+    environment {
+      variables = {
+        BEDROCK_DB_HOST = $$BEDROCK_DB_HOST$$
+      }
+    }
 }
 
 output "create_etl_run_map_arn" {


### PR DESCRIPTION
Added BEDROCK_DB_HOST to create_etl_run_map environment when set in make_variables
