### PR TITLE
Turn off CORS origin restrictions

### DIFF
--- a/src/api/api-gateways/bedrock-api/deploy/config.tf
+++ b/src/api/api-gateways/bedrock-api/deploy/config.tf
@@ -6,6 +6,9 @@ resource "aws_apigatewayv2_api" "aws_apigatewayv2_api-$$INSTANCE$$" {
   name          = "bedrock-api-$$INSTANCE$$"
   protocol_type = "HTTP"
   target        = data.terraform_remote_state.bedrock_api_backend_lambda.outputs.bedrock-api-backend_arn
+  cors_configuration {
+    allow_origins = ["*"]
+  }
 }
 
 resource "aws_lambda_permission" "apigw-$$INSTANCE$$" {


### PR DESCRIPTION
Talking with Rick, it's easy to get around CORS with a browser extension and there are hassles maintaining the list of allowed origins in the configuration, so just turning it off in favor of enforcing restrictions in the API lambda itself. There it's easy to maintain the list of allowed sites in a DB table, for example, to keep things more dynamic and to prevent clients from subverting.
