### PR TITLE
sog data. load_assets allows mult assets per dir

### DIFF
--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/billed_water_volume.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/billed_water_volume.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_billed_water_volume.ncb",
+  "description": "Water SOG Benchmark: Billed Water Volume",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "billed_water_volume"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/filter_run_time.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/filter_run_time.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_filter_run_time.ncb",
+  "description": "Water SOG Benchmark: Filter Run Time",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "filter_run_time"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/filter_run_volume.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/filter_run_volume.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_filter_run_volume.ncb",
+  "description": "Water SOG Benchmark: Filter Run Volume",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "filter_run_volume"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/finished_water_volume.ncb.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/finished_water_volume.ncb.json
@@ -2,7 +2,8 @@
   "asset_name": "sog_finished_water_volume.ncb",
   "description": "Water SOG Benchmark: Finished Water Volume",
   "location": {
-    "asset": "sog_finished_water_volume.ncb"
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "finished_water_volume"
   },
   "active": true,
   "depends": [],

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/max_water_turbidity.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/max_water_turbidity.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_max_water_turbidity.ncb",
+  "description": "Water SOG Benchmark: max_water_turbidity",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "max_water_turbidity"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/other_water_meter_count.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/other_water_meter_count.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_other_water_meter_count.ncb",
+  "description": "Water SOG Benchmark: other_water_meter_count",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "other_water_meter_count"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/pump_station_count.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/pump_station_count.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_pump_station_count.ncb",
+  "description": "Water SOG Benchmark: pump_station_count",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "pump_station_count"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/purchased_water_volume.ncb.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/purchased_water_volume.ncb.json
@@ -2,7 +2,8 @@
   "asset_name": "sog_purchased_water_volume.ncb",
   "description": "Water SOG Benchmark: Purchased Water Volume",
   "location": {
-    "asset": "sog_purchased_water_volume.ncb"
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "purchased_water_volume"
   },
   "active": true,
   "depends": [],

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/residential_water_meter_count.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/residential_water_meter_count.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_residential_water_meter_count.ncb",
+  "description": "Water SOG Benchmark: residential_water_meter_count",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "residential_water_meter_count"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_average_turbidity.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_average_turbidity.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_average_turbidity.ncb",
+  "description": "Water SOG Benchmark: water_average_turbidity",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_average_turbidity"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_breaks_leaks_count.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_breaks_leaks_count.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_breaks_leaks_count.ncb",
+  "description": "Water SOG Benchmark: water_breaks_leaks_count",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_breaks_leaks_count"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_chlorine.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_chlorine.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_chlorine.ncb",
+  "description": "Water SOG Benchmark: water_chlorine",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_chlorine"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_coliform.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_coliform.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_coliform.ncb",
+  "description": "Water SOG Benchmark: water_coliform",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_coliform"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_fluoride.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_fluoride.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_fluoride.ncb",
+  "description": "Water SOG Benchmark: water_fluoride",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_fluoride"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_hardness.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_hardness.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_hardness.ncb",
+  "description": "Water SOG Benchmark: water_hardness",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_hardness"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_iron.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_iron.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_iron.ncb",
+  "description": "Water SOG Benchmark: water_iron",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_iron"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_ph.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_ph.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_ph.ncb",
+  "description": "Water SOG Benchmark: water_ph",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_ph"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_pipe_inch_diameter_miles.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_pipe_inch_diameter_miles.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_pipe_inch_diameter_miles.ncb",
+  "description": "Water SOG Benchmark: water_pipe_inch_diameter_miles",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_pipe_inch_diameter_miles"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_pipe_miles.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_pipe_miles.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_pipe_miles.ncb",
+  "description": "Water SOG Benchmark: water_pipe_miles",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_pipe_miles"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_plant_count.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_plant_count.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_plant_count.ncb",
+  "description": "Water SOG Benchmark: water_plant_count",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_plant_count"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_regulatory_violations_count.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_regulatory_violations_count.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_regulatory_violations_count.ncb",
+  "description": "Water SOG Benchmark: water_regulatory_violations_count",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_regulatory_violations_count"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_thm.json
+++ b/src/db/bedrock-db-data/test_data/assets/sog.ncb/water_thm.json
@@ -1,0 +1,13 @@
+{
+  "asset_name": "sog_water_thm.ncb",
+  "description": "Water SOG Benchmark: water_thm",
+  "location": {
+    "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4",
+    "tab": "water_thm"
+  },
+  "active": true,
+  "depends": [],
+  "tags": [
+    "nc_benchmarks"
+  ]
+}


### PR DESCRIPTION
Files created for SOG NC Benchmark data. Each SOG asset is tagged nc_benchmark, and has a spreadsheetid and a tab. 

Other info needed, such as Google service account password, target table, and source sheet range will be encoded in the new nc_benchmark etl type.