### PR TITLE
add crlf option for csv files

### DIFF
--- a/docs/etl_formats.md
+++ b/docs/etl_formats.md
@@ -48,7 +48,8 @@ Also see [Managed Data Assets README](https://github.com/cityofasheville/managed
             <OPTIONAL>: "tableheaders": true (this is mainly used for creating csv files)
             <OPTIONAL> "sortasc": "fieldname",
             <OPTIONAL> "sortdesc": "fieldname",
-            <OPTIONAL> "fixedwidth_noquotes": true  (Tables converted to csv by default have strings with double quotes in the data quoted. For fixed width and XML files we don't want that)                               
+            <OPTIONAL> "fixedwidth_noquotes": true,  (Tables converted to csv by default have strings with double quotes in the data quoted. For fixed width and XML files we don't want that)
+            <OPTIONAL> "crlf": true,                 (Tables converted to csv by default use record delimiters of LF. Set this true to use CRLF.)    
             __TARGET OPTIONS__
             <OPTIONAL> "append": true  (By default, data is overwritten in table. Set to true to append as new rows.)       
             <OPTIONAL> "append_serial": "fieldname"  (Adds an integer auto-numbering key field to target table. A serial field with this name must appear as the last field in the target table.)

--- a/src/db/bedrock-db-data/test_data/assets/aclara.s3/aclara.s3.ETL.json
+++ b/src/db/bedrock-db-data/test_data/assets/aclara.s3/aclara.s3.ETL.json
@@ -6,7 +6,8 @@
       "type": "table_copy",
       "active": true,
       "source_location": {
-        "asset": "aclara.mun"
+        "asset": "aclara.mun",
+        "crlf": true
       },
       "target_location": {
         "asset": "aclara.s3"

--- a/src/etl/lambdas/etl_task_table_copy/getPgStream.js
+++ b/src/etl/lambdas/etl_task_table_copy/getPgStream.js
@@ -66,7 +66,9 @@ function getPgStream(location) {
             if (location.fixedwidth_noquotes) {
               reject(new Error("Postgres 'fixedwidth_noquotes' not implemented"));
             }
-
+            if (location.crlf) {
+              reject(new Error("Postgres 'crlf' not implemented"));
+            }
             const queryString = `COPY (SELECT * FROM ${tablename} 
               ${copySinceQuery}
               ${orderby}) TO STDOUT WITH (FORMAT csv ${tableheaders})`;

--- a/src/etl/lambdas/etl_task_table_copy/getSsStream.js
+++ b/src/etl/lambdas/etl_task_table_copy/getSsStream.js
@@ -99,6 +99,9 @@ async function getSsStream(location) {
                   stringifyOptions.quote = '';
                   stringifyOptions.escape = '';
                 }
+                if (location.crlf) {
+                  stringifyOptions.record_delimiter = 'windows'
+                }
                 nonObjStream = request
                   .pipe(csv.stringify(stringifyOptions));
               }


### PR DESCRIPTION
The new FTP feed for Aclara requires CRLF record delimiters in its csv files. All our other vendors accept the default LF used by the csv-stringify package.
I looked up the RFC for csv files, and CRLF is actually recommended (but says many implementations differ.)
But I hate to change our default at this point with so many LFs in production, so... yet another option switch.
