### PR TITLE
added disable_algorithms option to file copy to enable Paymentus

### DIFF
--- a/docs/secrets.manager.example.md
+++ b/docs/secrets.manager.example.md
@@ -13,7 +13,8 @@ Secrets Manager holds data in these formats:
 We name database connections with names like "servername/database/username".
 In Secrets Manager we create them as "Other type of secret" and then "Plaintext", which allows you to add key/values as JSON.
 
-## For table_copy and sql
+## Databases
+### (table_copy and sql)
 ```
     {
         "type": "postgresql",
@@ -36,7 +37,8 @@ In Secrets Manager we create them as "Other type of secret" and then "Plaintext"
         "description": "Servername:  AD Authentication"
     }
 ```
-## For table_copy    
+## Google Sheets
+### (table_copy)
 ```
     {
         "type": "google_sheets",
@@ -44,14 +46,20 @@ In Secrets Manager we create them as "Other type of secret" and then "Plaintext"
         "private_key": "-----BEGIN PRIVATE KEY-----ihflieurbvliasubfv....."
     }
 ```
-## For table_copy and file_copy (S3 table_copy files are csv by default or fixed width, created in SQL and optionally given the "fixedwidth_noquotes".)
+## S3
+## (table_copy and file_copy) 
+## S3 table_copy files are csv by default or fixed width, created in SQL and optionally given the "fixedwidth_noquotes".
 ```
     {
         "type": "s3",
         "s3_bucket": "bedrock-data-files"
     }
 ```
-## For file_copy and sftp and encrypt    
+## SFTP
+### (file_copy and sftp and encrypt)
+### Use either password or private_key to connect
+### pgp_key is used for encrypting file before sending
+### Optional: disabled_algorithms might be needed in unusual circumstances (see paramiko docs)
 ```
     {
         "type": "sftp",
@@ -59,11 +67,19 @@ In Secrets Manager we create them as "Other type of secret" and then "Plaintext"
         "port": 22,
         "username": "bedrock",
         "password": "xxxxx",
-        "pgp_key": "-----BEGIN PGP PUBLIC KEY BLOCK-iuygqwerfibhu...."
+        "private_key": "-----BEGIN RSA PRIVATE KEY-----\nasdfgy",
+        "pgp_key": "-----BEGIN PGP PUBLIC KEY BLOCK-iuygqwerfibhu....",
+        "disabled_algorithms": {
+            "pubkeys": [
+                "rsa-sha2-512",
+                "rsa-sha2-256"
+            ]
+        },
     }
 ```
 
-## For encrypt
+## Encryption
+### (encrypt)
 ```
     {
         "type": "encrypt",

--- a/src/db/bedrock-db-data/test_data/assets/_paymentus_down.ftp/paymentus_down.ftp.ETL.json
+++ b/src/db/bedrock-db-data/test_data/assets/_paymentus_down.ftp/paymentus_down.ftp.ETL.json
@@ -1,0 +1,41 @@
+{
+  "asset_name": "paymentus_down.ftp",
+  "run_group": "paymentus_down",
+  "tasks": [
+    {
+      "type": "file_copy",
+      "source_location": {
+        "connection": "paymentus_ftp",
+        "filename": "ashv-paper-suppression-${YYYY}${MM}${DD}.csv",
+        "path": "/suspended/"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "ashv-paper-suppression-${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+      "active": false
+    },
+    {
+      "type": "table_copy",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "ashv-paper-suppression-${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "munis/munprod/fme_jobs",
+        "loctype": "db",
+        "schemaname": "avl",
+        "tablename": "Paymentus_Paper_Suppression_Table"
+      },
+      "active": false
+    },
+    {
+      "type": "sql",
+      "active": true,
+      "connection": "munis/munprod/fme_jobs",
+      "sql_string": "execute avl.Paymentus_Paper_Suppression_Update;"
+    }
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/_paymentus_down.ftp/paymentus_down.ftp.json
+++ b/src/db/bedrock-db-data/test_data/assets/_paymentus_down.ftp/paymentus_down.ftp.json
@@ -1,0 +1,11 @@
+{
+    "asset_name": "paymentus_down.ftp",
+    "location": "ftp_site",
+    "active": true,
+    "type": "ftp_site",
+    "description": "Download Paper Supression file from Paymentus",
+    "depends": [],
+    "owner_id": null,
+    "notes": null,
+    "tags": []
+  }

--- a/src/db/bedrock-db-data/test_data/assets/_paymentus_up.ftp/paymentus_up.ftp.ETL.json
+++ b/src/db/bedrock-db-data/test_data/assets/_paymentus_up.ftp/paymentus_up.ftp.ETL.json
@@ -1,0 +1,186 @@
+{
+  "asset_name": "paymentus_up.ftp",
+  "run_group": "paymentus_up",
+  "tasks": [
+    {
+      "type": "table_copy",
+      "description": "Create empty control file",
+      "source_location": {
+        "connection": "pubrecdb1/mdastore1/dbadmin",
+        "schemaname": "internal",
+        "tablename": "emptydata"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "CIF${YYYY}${MM}${DD}.ctl",
+        "path": "paymentus/"
+      },
+  "active": true
+    },
+    {
+      "type": "table_copy",
+      "description": "Create empty control file",
+      "source_location": {
+        "connection": "pubrecdb1/mdastore1/dbadmin",
+        "schemaname": "internal",
+        "tablename": "emptydata"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "Payment${YYYY}${MM}${DD}.ctl",
+        "path": "paymentus/"
+      },
+  "active": true
+    },
+    {
+      "type": "table_copy",
+      "description": "Create empty control file",
+      "source_location": {
+        "connection": "pubrecdb1/mdastore1/dbadmin",
+        "schemaname": "internal",
+        "tablename": "emptydata"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "Susp${YYYY}${MM}${DD}.ctl",
+        "path": "paymentus/"
+      },
+  "active": true
+    },
+    {
+      "type": "table_copy",
+      "description": "Copy Paymentus CIF to S3",
+      "source_location": {
+        "connection": "munis/munprod/mssqlgisadmin",
+        "schemaname": "amd",
+        "tablename": "ub_pm_cif_file"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "CIF${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+  "active": true
+    },
+    {
+      "type": "file_copy",
+      "description": "Copy Paymentus CIF to FTP site",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "CIF${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "paymentus_ftp",
+        "filename": "CIF${YYYY}${MM}${DD}.csv",
+        "path": "/processed/"
+      },
+  "active": true
+    },
+    {
+      "type": "file_copy",
+      "description": "Copy 'ctl' file to FTP site",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "CIF${YYYY}${MM}${DD}.ctl",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "paymentus_ftp",
+        "filename": "CIF${YYYY}${MM}${DD}.ctl",
+        "path": "/processed/"
+      },
+  "active": true
+    },
+    {
+      "type": "table_copy",
+      "description": "Copy Paymentus Payment History to S3",
+      "source_location": {
+        "connection": "munis/munprod/mssqlgisadmin",
+        "schemaname": "amd",
+        "tablename": "ub_pm_payment_history_loader_today_no_ivr"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "Payment${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+  "active": true
+    },
+    {
+      "type": "file_copy",
+      "description": "Copy Paymentus Payment History to FTP site",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "Payment${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "paymentus_ftp",
+        "filename": "Payment${YYYY}${MM}${DD}.csv",
+        "path": "/processed/"
+      },
+  "active": true
+    },
+    {
+      "type": "file_copy",
+      "description": "Copy 'ctl' file to FTP site",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "Payment${YYYY}${MM}${DD}.ctl",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "paymentus_ftp",
+        "filename": "Payment${YYYY}${MM}${DD}.ctl",
+        "path": "/processed/"
+      },
+  "active": true
+    },
+    {
+      "type": "table_copy",
+      "description": "Copy Paymentus Suspended Accounts to S3",
+      "source_location": {
+        "connection": "munis/munprod/mssqlgisadmin",
+        "schemaname": "amd",
+        "tablename": "ub_pm_suspended_accounts"
+      },
+      "target_location": {
+        "connection": "s3_data_files",
+        "filename": "Susp${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+  "active": true
+    },
+    {
+      "type": "file_copy",
+      "description": "Copy Paymentus Suspended Accounts to FTP site",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "Susp${YYYY}${MM}${DD}.csv",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "paymentus_ftp",
+        "filename": "Susp${YYYY}${MM}${DD}.csv",
+        "path": "/processed/"
+      },
+  "active": true
+    },
+    {
+      "type": "file_copy",
+      "description": "Copy 'ctl' file to FTP site",
+      "source_location": {
+        "connection": "s3_data_files",
+        "filename": "Susp${YYYY}${MM}${DD}.ctl",
+        "path": "paymentus/"
+      },
+      "target_location": {
+        "connection": "paymentus_ftp",
+        "filename": "Susp${YYYY}${MM}${DD}.ctl",
+        "path": "/processed/"
+      },
+  "active": true
+    }
+  ]
+}

--- a/src/db/bedrock-db-data/test_data/assets/_paymentus_up.ftp/paymentus_up.ftp.json
+++ b/src/db/bedrock-db-data/test_data/assets/_paymentus_up.ftp/paymentus_up.ftp.json
@@ -1,0 +1,11 @@
+{
+    "asset_name": "paymentus_up.ftp",
+    "location": "ftp_site",
+    "active": true,
+    "type": "ftp_site",
+    "description": "Uploaded three data files and three matching empty ctl files to Paymentus",
+    "depends": [],
+    "owner_id": null,
+    "notes": null,
+    "tags": []
+  }

--- a/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
@@ -29,16 +29,25 @@ def connectToFTP(connection_data):
         ftp_host = connection_data['host']
         ftp_port = connection_data['port']
         ftp_user = connection_data['username']
-        transport = paramiko.Transport((ftp_host, int(ftp_port)))
+        if 'disabled_algorithms' in connection_data:
+            disabled_algorithms = connection_data['disabled_algorithms']
+        else:
+            disabled_algorithms = None
+        transport = paramiko.Transport(ftp_host +
+                                       ':' + str(ftp_port),
+                                       disabled_algorithms=disabled_algorithms
+                                       )
         transport.start_client(timeout=60)
 
         if 'password' in connection_data.keys():
-            transport.auth_password(username = ftp_user, password = connection_data['password'])
-        elif 'privateKey' in connection_data.keys():
-            pk = paramiko.RSAKey.from_private_key(io.StringIO(connection_data['privateKey']))
-            transport.auth_publickey(username = ftp_user, key = pk)
-        sftp = paramiko.SFTPClient.from_transport(transport)
-        return sftp
+            transport.auth_password(
+                    username=ftp_user, password=connection_data['password'])
+        elif 'private_key' in connection_data.keys():
+            pk = paramiko.RSAKey.from_private_key(
+                    io.StringIO(connection_data['private_key']))
+            transport.auth_publickey(username=ftp_user, key=pk)
+            sftp = paramiko.SFTPClient.from_transport(transport)
+            return sftp
     except BaseException as err:
         raise Exception("Connect to FTP Error: " + str(err))
  

--- a/src/etl/lambdas/etl_task_sftp/handler.py
+++ b/src/etl/lambdas/etl_task_sftp/handler.py
@@ -122,8 +122,8 @@ def lambda_handler(event, context):
         if 'password' in ftp_conn.keys():
             ftp_pw   = ftp_conn['password']
             sftp = connectToFTP(ftp_host, ftp_port, ftp_user, ftp_pw=ftp_pw, ftp_keyfile=None)
-        if 'privateKey' in ftp_conn.keys():
-            ftp_keyfile = ftp_conn['privateKey']
+        if 'private_key' in ftp_conn.keys():
+            ftp_keyfile = ftp_conn['private_key']
             filelikeobj = io.StringIO(ftp_keyfile)
             pk = paramiko.RSAKey.from_private_key(filelikeobj)
             sftp = connectToFTP(ftp_host, ftp_port, ftp_user, ftp_pw=None, ftp_keyfile=pk)


### PR DESCRIPTION
I am porting Paymentus to Bedrock. 
- New asset/etl files
- New feature for file_copy: 'disabled_algorithms'
- Rename privateKey to private_key for consistency.
- Docs

