### PR TITLE
Fix empty tags

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/updateAsset.js
@@ -175,35 +175,37 @@ async function updateAsset(requestBody, pathElements, queryParams, connection) {
       }
     }
     // For now, just add any tags that aren't in the tags table
-    sql = 'SELECT tag_name from bedrock.tags where tag_name in (';
-    cnt = 1;
-    for (let i = 0, comma = ''; i < tags.length; i += 1, comma = ', ', cnt += 1) {
-      sql += `${comma}$${cnt}`;
-    }
-    sql += ');';
-    res = await client.query(sql, tags)
-      .catch((err) => {
-        result.error = true;
-        result.message = `PG error reading tags for update: ${pgErrorCodes[err.code]}`;
-        result.result = null;
-      });
-
-    if (!result.error && res.rowCount !== tags.length) {
-      const dbTags = [];
-      for (let i = 0; i < res.rowCount; i += 1) {
-        dbTags.push(res.rows[i].tag_name);
+    if (tags.length > 0) {
+      sql = 'SELECT tag_name from bedrock.tags where tag_name in (';
+      cnt = 1;
+      for (let i = 0, comma = ''; i < tags.length; i += 1, comma = ', ', cnt += 1) {
+        sql += `${comma}$${cnt}`;
       }
-      for (let i = 0; i < tags.length && !result.error; i += 1) {
-        if (!dbTags.includes(tags[i])) {
-          await client.query(
-            'INSERT INTO tags (tag_name) VALUES ($1)',
-            [tags[i]],
-          )
-            .catch((err) => {
-              result.error = true;
-              result.message = `PG error adding tags to tag table for update: ${pgErrorCodes[err.code]}`;
-              result.result = null;
-            });
+      sql += ');';
+      res = await client.query(sql, tags)
+        .catch((err) => {
+          result.error = true;
+          result.message = `PG error reading tags for update: ${pgErrorCodes[err.code]}`;
+          result.result = null;
+        });
+
+      if (!result.error && res.rowCount !== tags.length) {
+        const dbTags = [];
+        for (let i = 0; i < res.rowCount; i += 1) {
+          dbTags.push(res.rows[i].tag_name);
+        }
+        for (let i = 0; i < tags.length && !result.error; i += 1) {
+          if (!dbTags.includes(tags[i])) {
+            await client.query(
+              'INSERT INTO tags (tag_name) VALUES ($1)',
+              [tags[i]],
+            )
+              .catch((err) => {
+                result.error = true;
+                result.message = `PG error adding tags to tag table for update: ${pgErrorCodes[err.code]}`;
+                result.result = null;
+              });
+          }
         }
       }
     }
@@ -220,18 +222,20 @@ async function updateAsset(requestBody, pathElements, queryParams, connection) {
     }
 
     // And add the new ones back in
-    for (let i = 0; i < tags.length && !result.error; i += 1) {
-      res = await client.query(
-        'INSERT INTO bedrock.asset_tags (asset_name, tag_name) VALUES ($1, $2)',
-        [body.asset_name, tags[i]],
-      )
-        .catch((err) => {
-          result.error = true;
-          result.message = `PG error inserting tags for update: ${pgErrorCodes[err.code]}`;
-          result.result = null;
-        });
+    if (!result.error) {
+      for (let i = 0; i < tags.length && !result.error; i += 1) {
+        res = await client.query(
+          'INSERT INTO bedrock.asset_tags (asset_name, tag_name) VALUES ($1, $2)',
+          [body.asset_name, tags[i]],
+        )
+          .catch((err) => {
+            result.error = true;
+            result.message = `PG error inserting tags for update: ${pgErrorCodes[err.code]}`;
+            result.result = null;
+          });
+      }
+      result.result.tags = body.tags;
     }
-    result.result.tags = body.tags;
   }
 
   if (result.error) {


### PR DESCRIPTION
@CameronHenshaw found a bug in the asset update endpoint where you couldn't set tags to an empty set - there was a query error that then cascaded to some unprotected code and gave us an error with no explanation. Both are fixed both in the update routine and in the add routine.
