### PR TITLE
Asset list cleanup

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
@@ -82,7 +82,6 @@ async function getBase(offset, count, whereClause, client) {
   const result = {
     rows: [],
     assets: [],
-    rowCount: null,
   };
 
   try {
@@ -107,7 +106,6 @@ async function getBase(offset, count, whereClause, client) {
       },
     );
   }
-  result.rowCount = res.rowCount;
   return result;
 }
 
@@ -226,7 +224,7 @@ async function getAssetList(domainName, pathElements, queryParams, connection) {
   result.result = {
     items: res.rows,
     offset,
-    count: res.rowCount,
+    count: res.rows.length,
     total,
     url,
   };


### PR DESCRIPTION
So I moved some of the code around so that getBase and getDependencies now contain some of the code that followed them originally. 

I thought it made more sense to keep those functions as they are instead of creating new functions just for those bits of formatting code- seemed like splitting the code more would make it harder to follow.

I still don't know if it's super intuitive though... Maybe it's fine, but happy to take another pass at it if needed.  