### PR TITLE
Fix rungroups issue

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/makefile
+++ b/src/api/lambdas/bedrock-api-backend/makefile
@@ -6,7 +6,7 @@ dirs = build
 SRC_DIR := ./deploy
 DEST_DIR := ./build
 TFFILES := config.tf datablocks.tf backend.tf local.tfvars variables.tf makefile
-code_files = ./*.js ./*.json ./assets ./rungroups
+code_files = ./*.js ./*.json ./assets/*.js ./rungroups/*.js
 
 TF_TARGS := $(patsubst %,$(DEST_DIR)/%,$(TFFILES))
 

--- a/src/api/lambdas/bedrock-api-backend/rungroups/getRungroup.js
+++ b/src/api/lambdas/bedrock-api-backend/rungroups/getRungroup.js
@@ -44,7 +44,7 @@ async function getRungroup(pathElements, queryParams, connection) {
   }
 
   try {
-    result.result = await getInfo(client);
+    result.result = await getInfo(client, pathElements);
     await client.end();
   } catch (error) {
     result.error = true;

--- a/src/api/lambdas/bedrock-api-backend/rungroups/handleRungroups.js
+++ b/src/api/lambdas/bedrock-api-backend/rungroups/handleRungroups.js
@@ -18,8 +18,10 @@ async function handleRungroups(
     message: '',
     result: null,
   };
+  let nParams = pathElements.length;
+  if (nParams == 2 && (pathElements[1] === null || pathElements[1].length == 0)) nParams = 1;
 
-  switch (pathElements.length) {
+  switch (nParams) {
     // GET rungroups
     case 1:
       result = await getRungroupList(


### PR DESCRIPTION
Getting a single rungroup was not working since pathElements wasn't being passed to getInfo. Also fixed to recognize a trailing slash without a following element as the same as without a slash.  Along the way realized that the makefile didn't define code_files to include all the .js files in subdirectories - fixed.
