### PR TITLE
Additional metadata fields and custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ The layer above the inventory is comprised of two applications: an ETL (extract-
 
 Once the API is complete, a third application layer consisting of specialized frontends is planned for development.
 
+### Bedrock Metadata
+
+There are three types of metadata maintained in the Bedrock database: core fields, custom fields, and ETL information.
+
+The core fields are kept to a minimum. The consist of basic information like the name and type of the asset, a brief description and notes, where it is, who owns it, whether it is active, and a link which can be used to access more complete documentation. The best place to see the current set of core fields is in the [SQL script that creates the ```assets``` table in the database](./src/db/bedrock-db/createNewBedrockDB.sql).
+
+Bedrock also allows custom fields to be defined for individual types. A ```custom_fields``` table in the database stores any additional fields (name and type) associated with a given ```asset_type```. The values themselves are stored in a ```custom_values``` table. The logic to access or set custom values may be seen in the various [asset endpoints in the API](./src/api/lambdas/bedrock-api-backend/assets/).
+
+ETL information consists of a sequence of tasks that either move data from one location to another or invoke a SQL or Lambda function. The ETL tasks for a given asset are associated with a "run group", which is then associated with a schedule. _NOTE: This needs better documentation._
+
 ### Bedrock ETL (in production)
 The Bedrock ETL system allows groups of ETL jobs to be run on a schedule, with the internal ordering of jobs within a group (such as the daily overnight run)  determined automatically based on dependency information for the assets involved. At the end of a run, a summary report of job successes or failures is emailed to administrators. Transfers are transactional (so a failed job will not leave the data in an inconsistent state) and, because Bedrock has dependency information, the failure of a transfer will cause all dependent jobs to be “pruned” so that errors are not propagated. 
 

--- a/docs/deploy-notes.md
+++ b/docs/deploy-notes.md
@@ -7,7 +7,7 @@ Create a file `make_variables` based on `make_variables.sample`. Change INSTANCE
 
 The variable build_mode can be set to "std" if deploying from Linux or "sam" to use a container. This is needed for two Python Lambdas that need Linux native compilation targets for encryption used by the paramiko package.
 
-To start, cd into ```src/bedrock_common`` and run
+To start, cd into ```src/bedrock_common``` and run
 
 ```bash
 make init

--- a/docs/deploy-notes.md
+++ b/docs/deploy-notes.md
@@ -7,10 +7,10 @@ Create a file `make_variables` based on `make_variables.sample`. Change INSTANCE
 
 The variable build_mode can be set to "std" if deploying from Linux or "sam" to use a container. This is needed for two Python Lambdas that need Linux native compilation targets for encryption used by the paramiko package.
 
-To start, cd into ```src/bedrock_common`` and run the following. 
+To start, cd into ```src/bedrock_common`` and run
 ```bash
 make init
-make apply-y
+make apply
 ```
 
 Then cd into each other directory in ```src``` and run ```make``` commands to create the infrastructure.

--- a/docs/deploy-notes.md
+++ b/docs/deploy-notes.md
@@ -8,6 +8,7 @@ Create a file `make_variables` based on `make_variables.sample`. Change INSTANCE
 The variable build_mode can be set to "std" if deploying from Linux or "sam" to use a container. This is needed for two Python Lambdas that need Linux native compilation targets for encryption used by the paramiko package.
 
 To start, cd into ```src/bedrock_common`` and run
+
 ```bash
 make init
 make apply
@@ -26,7 +27,7 @@ make apply
 ```sh
 cd src/bedrock_common
 make init
-make apply-y
+make apply
 ```
 If you are using an existing database, set the value of ```BEDROCK_DB_HOST``` in src/make_variables to the host name of that database and skip the next set of commands.
 ```sh

--- a/docs/deploy-notes.md
+++ b/docs/deploy-notes.md
@@ -7,11 +7,10 @@ Create a file `make_variables` based on `make_variables.sample`. Change INSTANCE
 
 The variable build_mode can be set to "std" if deploying from Linux or "sam" to use a container. This is needed for two Python Lambdas that need Linux native compilation targets for encryption used by the paramiko package.
 
-To start, cd into ```src/bedrock_common``` and run 
-
+To start, cd into ```src/bedrock_common`` and run the following. 
 ```bash
 make init
-make apply
+make apply-y
 ```
 
 Then cd into each other directory in ```src``` and run ```make``` commands to create the infrastructure.
@@ -27,7 +26,7 @@ make apply
 ```sh
 cd src/bedrock_common
 make init
-make apply
+make apply-y
 ```
 If you are using an existing database, set the value of ```BEDROCK_DB_HOST``` in src/make_variables to the host name of that database and skip the next set of commands.
 ```sh

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -175,7 +175,7 @@ async function baseInsert(body, customFields, client) {
     for (let i = 0; i < customFields.length; i += 1) {
       const field_name = customFields[i].field_name;
       if (field_name in body) {
-        args = [body.asset_type, field_name, body[field_name]];
+        args = [body.asset_name, field_name, body[field_name]];
         try {
           res = await client.query(sql, args);
         }

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -78,7 +78,6 @@ async function getCustomFields(client, asset_type) {
   if (res.rowCount > 0) {
     customFields = res.rows;
   }
-  console.log('Custom fields: ', customFields);
   return customFields;
 }
 
@@ -342,7 +341,6 @@ async function addAsset(requestBody, pathElements, queryParams, connection) {
     if ('asset_type' in body) {
       customFields = await getCustomFields(client, body.asset_type);
     }
-
   } catch (error) {
     await client.end();
     result.error = true;

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -89,6 +89,28 @@ async function baseInsert(body, client) {
     args.push(body.notes);
     argnum += 1;
   }
+
+  if ('link' in body) {
+    sql += ', link';
+    vals += `, $${argnum}`;
+    args.push(body.link);
+    argnum += 1;
+  }
+
+  if ('display_name' in body) {
+    sql += ', display_name';
+    vals += `, $${argnum}`;
+    args.push(body.display_name);
+    argnum += 1;
+  }
+
+  if ('asset_type' in body) {
+    sql += ', asset_type';
+    vals += `, $${argnum}`;
+    args.push(body.asset_type);
+    argnum += 1;
+  }
+
   sql += `${vals})`;
 
   try {
@@ -113,6 +135,15 @@ async function baseInsert(body, client) {
     }
     if ('notes' in body) {
       info.notes = body.notes;
+    }
+    if ('link' in body) {
+      info.link = body.link
+    }
+    if ('display_name' in body) {
+      info.display_name = body.display_name
+    }
+    if ('asset_type' in body) {
+      info.asset_type = body.asset_type
     }
   }
   return info;

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -59,6 +59,14 @@ async function tagsDelete(client, assetName) {
   }
 }
 
+async function customFieldsDelete (client, assetName) {
+  try {
+    await client.query('delete from bedrock.custom_values where asset_name = $1', [assetName]);
+  } catch (error) {
+    throw new Error(`PG error deleting asset custom values: ${pgErrorCodes[error.code]}`);
+  }
+}
+
 async function baseDelete(client, assetName) {
   try {
     await client.query('delete from assets where asset_name = $1;', [assetName]);
@@ -100,6 +108,7 @@ async function deleteAsset(pathElements, queryParams, connection) {
     await dependenciesDelete(client, assetName);
     await etlDelete(client, assetName);
     await tagsDelete(client, assetName);
+    await customFieldsDelete(client, assetName);
     await baseDelete(client, assetName);
     await client.query('COMMIT');
     await client.end();

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -33,6 +33,30 @@ async function readAsset(client, pathElements) {
   return res.rows;
 }
 
+async function getCustomFields(client, assetRows, fields, fieldsOverride) {
+  let res;
+  let customFields = [];
+  if ('asset_type' in assetRows[0] && assetRows[0].asset_type !== null) {
+    const sql = 'SELECT field_name, field_value from bedrock.custom_values where asset_name like $1';
+    try {
+      res = await client.query(sql, [assetRows[0].asset_name]);
+    } catch (error) {
+      throw new Error(
+        `PG error getting custom fields: ${pgErrorCodes[error.code]}`,
+      );
+    }
+    if (res.rowCount > 0) {
+      for (let i = 0; i < res.rowCount; i += 1) {
+        if (!fieldsOverride || fields.includes(res.rows[i].field_name)) {
+          customFields.push(res.rows[i]);
+        }
+      }
+    }
+  }
+
+  return customFields;
+}
+
 async function addInfo(res, fields, available) {
   const result = {
     asset_name: res[0].asset_name,
@@ -107,6 +131,7 @@ async function getAsset(pathElements, queryParams, connection) {
   }
 
   let fields = null;
+  let fieldsOverride = false;
   const available = [
     'display_name',
     'asset_type',
@@ -125,11 +150,19 @@ async function getAsset(pathElements, queryParams, connection) {
   // Use fields from the query if they're present, otherwise use all available fields
   if ('fields' in queryParams) {
     fields = queryParams.fields.replace('[', '').replace(']', '').split(',');
+    fieldsOverride = true;
   } else {
     fields = [...available];
   }
 
   result.result = await addInfo(res, fields, available);
+  const customFields = await getCustomFields(client, res, fields, fieldsOverride);
+  if (customFields.length > 0) {
+    for (let i = 0; i < customFields.length; i += 1) {
+      result.result[customFields[i].field_name] = customFields[i].field_value;
+    }
+  }
+
   if (fields === null || fields.includes('tags')) {
     try {
       res = await getTags(client, pathElements);

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -108,9 +108,12 @@ async function getAsset(pathElements, queryParams, connection) {
 
   let fields = null;
   const available = [
+    'display_name',
+    'asset_type',
     'description',
     'connection_class',
     'location',
+    'link',
     'active',
     'owner_id',
     'notes',

--- a/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
@@ -96,11 +96,14 @@ async function getBase(offset, count, whereClause, client) {
     result.rows.push(
       {
         asset_name: res.rows[i].asset_name,
+        display_name: res.rows[i].display_name,
         description: res.rows[i].description,
+        asset_type: res.rows[i].asset_type,
         connection_class: res.rows[i].connection_class,
         location: res.rows[i].location,
         owner_id: res.rows[i].owner_id,
         notes: res.rows[i].notes,
+        link: res.rows[i].link,
         active: res.rows[i].active,
         etl_run_group: res.rows[i].run_group,
         etl_active: res.rows[i].etl_active,

--- a/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
@@ -34,7 +34,7 @@ async function checkExistence(client, assetName) {
 }
 
 async function baseInsert(assetName, body, client) {
-  const members = ['description', 'location', 'active', 'owner_id', 'notes'];
+  const members = ['description', 'location', 'active', 'owner_id', 'notes', 'link', 'display_name', 'asset_type'];
   let cnt = 1;
   const args = [];
   let sql = 'UPDATE assets SET ';

--- a/src/db/bedrock-db-data/data/assets/abi_outreach_vendors.commodity.goog/abi_outreach_vendors.commodity.goog.json
+++ b/src/db/bedrock-db-data/data/assets/abi_outreach_vendors.commodity.goog/abi_outreach_vendors.commodity.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "abi_outreach_vendors.commodity.goog",
+  "display_name": null,
   "description": "List of MWBE vendors registered in Munis (not necessarily certified)",
   "location": {
     "tab": "Vendors By Commodity Code",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1lm_LdZS6yhniDEuVGyaj3vdD7ACU8Eo_pCkmNr81TvA"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "mwbe_vendors_by_commodity_non_aggregated.mun"

--- a/src/db/bedrock-db-data/data/assets/abi_outreach_vendors.goog/abi_outreach_vendors.goog.json
+++ b/src/db/bedrock-db-data/data/assets/abi_outreach_vendors.goog/abi_outreach_vendors.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "abi_outreach_vendors.goog",
+  "display_name": null,
   "description": "List of MWBE vendors registered in Munis (not necessarily certified)",
   "location": {
     "tab": "Vendors",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1lm_LdZS6yhniDEuVGyaj3vdD7ACU8Eo_pCkmNr81TvA"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "mwbe_vendors_by_commodity.mun",

--- a/src/db/bedrock-db-data/data/assets/abi_potential_vendors.goog/abi_potential_vendors.goog.json
+++ b/src/db/bedrock-db-data/data/assets/abi_potential_vendors.goog/abi_potential_vendors.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "abi_potential_vendors.goog",
+  "display_name": null,
   "description": "List of unregistered MWBE vendors who should be included in outreach efforts",
   "location": {
     "tab": "Vendors",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1lQzl5-MM0SUblcyuOdxsm6duaERA5017c4eSgbnlDoI"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/aclara.ftp/aclara.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/aclara.ftp/aclara.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aclara.ftp",
+  "display_name": null,
   "description": "Uploaded Accounting data to Aclara",
   "location": {
     "path": "/AclaraAccountImportFiles/",
     "filename": "AccountImport.imp",
     "connection": "aclara_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "aclara.s3"

--- a/src/db/bedrock-db-data/data/assets/aclara.mun/aclara.mun.json
+++ b/src/db/bedrock-db-data/data/assets/aclara.mun/aclara.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aclara.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "UB_AMI_3_Aclara_Account_Feed",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/aclara.s3/aclara.s3.json
+++ b/src/db/bedrock-db-data/data/assets/aclara.s3/aclara.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aclara.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "aclara/",
     "filename": "AccountImport_${YYYY}${MM}${DD}.imp",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "aclara.mun"

--- a/src/db/bedrock-db-data/data/assets/acumen_staff.api/acumen_staff.api.json
+++ b/src/db/bedrock-db-data/data/assets/acumen_staff.api/acumen_staff.api.json
@@ -1,11 +1,14 @@
 {
   "asset_name": "acumen_staff.api",
+  "display_name": null,
   "description": "Acumen Staff API",
   "location": {
     "connection": "acumen_api"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "acumen_staff.mun"

--- a/src/db/bedrock-db-data/data/assets/ad_info.lib/ad_info.lib.json
+++ b/src/db/bedrock-db-data/data/assets/ad_info.lib/ad_info.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "ad_info.lib",
+  "display_name": null,
   "description": "Active Directory info",
   "location": {
     "tablename": "ad_info",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "ad_info.mun"

--- a/src/db/bedrock-db-data/data/assets/ad_info.mun/ad_info.mun.json
+++ b/src/db/bedrock-db-data/data/assets/ad_info.mun/ad_info.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "ad_info.mun",
+  "display_name": null,
   "description": "Active Directory info",
   "location": {
     "tablename": "ad_info",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/aetna.ftp/aetna.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/aetna.ftp/aetna.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aetna.ftp",
+  "display_name": null,
   "description": "Uploaded staff data to Aetna",
   "location": {
     "path": "/AetnaSRC_Reports/toAetna/",
     "filename": "aetna_asheville_${YYYY}${MM}${DD}.csv",
     "connection": "aetna_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "aetna.s3"

--- a/src/db/bedrock-db-data/data/assets/aetna.s3/aetna.s3.json
+++ b/src/db/bedrock-db-data/data/assets/aetna.s3/aetna.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aetna.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "aetna/",
     "filename": "aetna_asheville_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_aetna_feed.mun"

--- a/src/db/bedrock-db-data/data/assets/aip.encrypted.s3/aip.encrypted.s3.json
+++ b/src/db/bedrock-db-data/data/assets/aip.encrypted.s3/aip.encrypted.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aip.encrypted.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "aip/",
     "filename": "CityofAsheville5871_To_InfoArmor_FULL_${YYYY}${MM}${DD}",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "aip.s3"

--- a/src/db/bedrock-db-data/data/assets/aip.ftp/aip.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/aip.ftp/aip.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aip.ftp",
+  "display_name": null,
   "description": "Uploaded staff data to AIP/Allstate/InfoArmor",
   "location": {
     "path": "/home/asheville-5871-sftp/inbound/",
     "filename": "CityofAsheville5871_To_InfoArmor_FULL_${YYYY}${MM}${DD}",
     "connection": "aip_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "aip.encrypted.s3"

--- a/src/db/bedrock-db-data/data/assets/aip.s3/aip.s3.json
+++ b/src/db/bedrock-db-data/data/assets/aip.s3/aip.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "aip.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "aip/",
     "filename": "CityofAsheville5871_To_InfoArmor_FULL_${YYYY}${MM}${DD}.txt",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_allstate_feed.mun"

--- a/src/db/bedrock-db-data/data/assets/ap_vendor.mun/ap_vendor.mun.json
+++ b/src/db/bedrock-db-data/data/assets/ap_vendor.mun/ap_vendor.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "ap_vendor.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "ap_vendor",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "dbo"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/arag.encrypted.s3/arag.encrypted.s3.json
+++ b/src/db/bedrock-db-data/data/assets/arag.encrypted.s3/arag.encrypted.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "arag.encrypted.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "arag/",
     "filename": "arag_asheville_${YYYY}${MM}${DD}.csv.pgp",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "arag.s3"

--- a/src/db/bedrock-db-data/data/assets/arag.ftp/arag.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/arag.ftp/arag.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "arag.ftp",
+  "display_name": null,
   "description": "Uploaded staff data to ARAG",
   "location": {
     "path": "/",
     "filename": "arag_asheville_${YYYY}${MM}${DD}.csv.pgp",
     "connection": "arag_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "arag.encrypted.s3"

--- a/src/db/bedrock-db-data/data/assets/arag.s3/arag.s3.json
+++ b/src/db/bedrock-db-data/data/assets/arag.s3/arag.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "arag.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "arag/",
     "filename": "arag_asheville_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_arag_feed.mun"

--- a/src/db/bedrock-db-data/data/assets/base_employee.lib/base_employee.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee.lib/base_employee.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee.lib",
+  "display_name": null,
   "description": "Standard Employee",
   "location": {
     "tablename": "base_employee",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_temp.lib"

--- a/src/db/bedrock-db-data/data/assets/base_employee.mun/base_employee.mun.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee.mun/base_employee.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee.mun",
+  "display_name": null,
   "description": "Standard Employee",
   "location": {
     "tablename": "base_employee",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl_bdv"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/base_employee_demographics.lib/base_employee_demographics.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_demographics.lib/base_employee_demographics.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_demographics.lib",
+  "display_name": null,
   "description": "Standard Employee - demographic data",
   "location": {
     "tablename": "base_employee_demographics",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_demographics.mun"

--- a/src/db/bedrock-db-data/data/assets/base_employee_demographics.mun/base_employee_demographics.mun.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_demographics.mun/base_employee_demographics.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_demographics.mun",
+  "display_name": null,
   "description": "Standard Employee - demographic data",
   "location": {
     "tablename": "base_employee_demographics",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl_bdv"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/base_employee_position.lib/base_employee_position.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_position.lib/base_employee_position.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_position.lib",
+  "display_name": null,
   "description": "Standard Employee Work fields: dept/supv/etc.",
   "location": {
     "tablename": "base_employee_position",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_position_temp.lib"

--- a/src/db/bedrock-db-data/data/assets/base_employee_position.mun/base_employee_position.mun.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_position.mun/base_employee_position.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_position.mun",
+  "display_name": null,
   "description": "Standard Employee Work fields: dept/supv/etc.",
   "location": {
     "tablename": "base_employee_position",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl_bdv"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/base_employee_position_temp.lib/base_employee_position_temp.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_position_temp.lib/base_employee_position_temp.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_position_temp.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "base_employee_position_temp",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "temp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_position.mun"

--- a/src/db/bedrock-db-data/data/assets/base_employee_private.lib/base_employee_private.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_private.lib/base_employee_private.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_private.lib",
+  "display_name": null,
   "description": "Standard Employee-Non public fields",
   "location": {
     "tablename": "base_employee_private",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_private.mun"

--- a/src/db/bedrock-db-data/data/assets/base_employee_private.mun/base_employee_private.mun.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_private.mun/base_employee_private.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_private.mun",
+  "display_name": null,
   "description": "Standard Employee-Non public fields",
   "location": {
     "tablename": "base_employee_private",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl_bdv"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/base_employee_sensitive_snapshots.lib/base_employee_sensitive_snapshots.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_sensitive_snapshots.lib/base_employee_sensitive_snapshots.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_sensitive_snapshots.lib",
+  "display_name": null,
   "description": "Monthly Snapshots of employee_sensitive view",
   "location": {
     "tablename": "base_employee_sensitive_snapshots",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_private.lib",

--- a/src/db/bedrock-db-data/data/assets/base_employee_temp.lib/base_employee_temp.lib.json
+++ b/src/db/bedrock-db-data/data/assets/base_employee_temp.lib/base_employee_temp.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "base_employee_temp.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "base_employee_temp",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "temp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee.mun"

--- a/src/db/bedrock-db-data/data/assets/bc_civicaddress_table.lib/bc_civicaddress_table.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bc_civicaddress_table.lib/bc_civicaddress_table.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_civicaddress_table.lib",
+  "display_name": null,
   "description": "Civic address table from County",
   "location": {
     "tablename": "bc_civicaddress_table",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_civicaddress_table.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_civicaddress_table.wh/bc_civicaddress_table.wh.json
+++ b/src/db/bedrock-db-data/data/assets/bc_civicaddress_table.wh/bc_civicaddress_table.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_civicaddress_table.wh",
+  "display_name": null,
   "description": "Civic address table from County",
   "location": {
     "tablename": "bc_civicaddress_table",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/bc_incorporated_areas.slope/bc_incorporated_areas.slope.json
+++ b/src/db/bedrock-db-data/data/assets/bc_incorporated_areas.slope/bc_incorporated_areas.slope.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_incorporated_areas.slope",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "bc_incorporated_areas",
     "connection": "pubrecdb1/steepslope/dbadmin",
     "schemaname": "public"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_incorporated_areas.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_incorporated_areas.wh/bc_incorporated_areas.wh.json
+++ b/src/db/bedrock-db-data/data/assets/bc_incorporated_areas.wh/bc_incorporated_areas.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_incorporated_areas.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "bc_incorporated_areas",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/bc_location.lib/bc_location.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bc_location.lib/bc_location.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_location.lib",
+  "display_name": null,
   "description": "Locations table from County",
   "location": {
     "tablename": "bc_location",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_location.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_location.wh/bc_location.wh.json
+++ b/src/db/bedrock-db-data/data/assets/bc_location.wh/bc_location.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_location.wh",
+  "display_name": null,
   "description": "Locations table from County",
   "location": {
     "tablename": "bc_location",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/bc_property.lib/bc_property.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bc_property.lib/bc_property.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_property.lib",
+  "display_name": null,
   "description": "Property table from County",
   "location": {
     "tablename": "bc_property",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_property.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_property.slope/bc_property.slope.json
+++ b/src/db/bedrock-db-data/data/assets/bc_property.slope/bc_property.slope.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_property.slope",
+  "display_name": null,
   "description": "Property table from County",
   "location": {
     "tablename": "bc_property",
     "connection": "pubrecdb1/steepslope/dbadmin",
     "schemaname": "public"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_property.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_property.wh/bc_property.wh.json
+++ b/src/db/bedrock-db-data/data/assets/bc_property.wh/bc_property.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_property.wh",
+  "display_name": null,
   "description": "Property table from County",
   "location": {
     "tablename": "bc_property",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/bc_property_account_master.lib/bc_property_account_master.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bc_property_account_master.lib/bc_property_account_master.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_property_account_master.lib",
+  "display_name": null,
   "description": "mdastore1 copy of amaccountmaster in Buncombe County",
   "location": {
     "tablename": "bc_property_account_master",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_property_account_master.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_property_account_master.wh/bc_property_account_master.wh.json
+++ b/src/db/bedrock-db-data/data/assets/bc_property_account_master.wh/bc_property_account_master.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_property_account_master.wh",
+  "display_name": null,
   "description": "mdastore1 copy of amaccountmaster in Buncombe County",
   "location": {
     "tablename": "bc_property_account_master",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/bc_property_pinnum_formatted_owner_names.lib/bc_property_pinnum_formatted_owner_names.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bc_property_pinnum_formatted_owner_names.lib/bc_property_pinnum_formatted_owner_names.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_property_pinnum_formatted_owner_names.lib",
+  "display_name": null,
   "description": "Preprocessed owner names",
   "location": {
     "tablename": "bc_property_pinnum_formatted_owner_names",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_property_account_master.lib",

--- a/src/db/bedrock-db-data/data/assets/bc_street.lib/bc_street.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bc_street.lib/bc_street.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_street.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "bc_street",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bc_street.wh"

--- a/src/db/bedrock-db-data/data/assets/bc_street.wh/bc_street.wh.json
+++ b/src/db/bedrock-db-data/data/assets/bc_street.wh/bc_street.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bc_street.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "bc_street",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/bike_counters.lib/bike_counters.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bike_counters.lib/bike_counters.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bike_counters.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "counters",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bike_counter"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "eco_visio.api"

--- a/src/db/bedrock-db-data/data/assets/bike_counters_by_type.lib/bike_counters_by_type.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bike_counters_by_type.lib/bike_counters_by_type.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bike_counters_by_type.lib",
+  "display_name": null,
   "description": "Bike Counters: View of 3 tables",
   "location": {
     "tablename": "bike_counters_by_type",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bike_counter"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bike_counters.lib",

--- a/src/db/bedrock-db-data/data/assets/bike_counters_by_type.pub/bike_counters_by_type.pub.json
+++ b/src/db/bedrock-db-data/data/assets/bike_counters_by_type.pub/bike_counters_by_type.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bike_counters_by_type.pub",
+  "display_name": null,
   "description": "Eco_Visio greenway pedestrian and bike counts-PublicDB",
   "location": {
     "tablename": "bike_counters_by_type",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "bike_counters.lib",

--- a/src/db/bedrock-db-data/data/assets/bike_counters_channels.lib/bike_counters_channels.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bike_counters_channels.lib/bike_counters_channels.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bike_counters_channels.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "counters_channels",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bike_counter"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "eco_visio.api",

--- a/src/db/bedrock-db-data/data/assets/bike_counters_counts.lib/bike_counters_counts.lib.json
+++ b/src/db/bedrock-db-data/data/assets/bike_counters_counts.lib/bike_counters_counts.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "bike_counters_counts.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "counter_counts",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bike_counter"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "eco_visio.api",

--- a/src/db/bedrock-db-data/data/assets/boards+commission_member_training.goog/boards+commission_member_training.goog.json
+++ b/src/db/bedrock-db-data/data/assets/boards+commission_member_training.goog/boards+commission_member_training.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "boards+commission_member_training.goog",
+  "display_name": null,
   "description": "",
   "location": {
     "tab": "Member Training",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1Efr6hn24-9e4eENkZy3Y_8uaYlYqFv4Iz2uqzrUwuRw"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/buncombe_tax_inspections.acc/buncombe_tax_inspections.acc.json
+++ b/src/db/bedrock-db-data/data/assets/buncombe_tax_inspections.acc/buncombe_tax_inspections.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "buncombe_tax_inspections.acc",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "BUNCOMBE_TAX_INSPECTIONS",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "dbo"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/buncombe_tax_inspections.lib/buncombe_tax_inspections.lib.json
+++ b/src/db/bedrock-db-data/data/assets/buncombe_tax_inspections.lib/buncombe_tax_inspections.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "buncombe_tax_inspections.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "buncombe_tax_inspections",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "buncombe_tax_inspections.acc"

--- a/src/db/bedrock-db-data/data/assets/buncombe_tax_inspections.pub/buncombe_tax_inspections.pub.json
+++ b/src/db/bedrock-db-data/data/assets/buncombe_tax_inspections.pub/buncombe_tax_inspections.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "buncombe_tax_inspections.pub",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "buncombe_tax_inspections",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "buncombe_tax_inspections.lib"

--- a/src/db/bedrock-db-data/data/assets/buncombe_tax_permits.acc/buncombe_tax_permits.acc.json
+++ b/src/db/bedrock-db-data/data/assets/buncombe_tax_permits.acc/buncombe_tax_permits.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "buncombe_tax_permits.acc",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "BUNCOMBE_TAX_PERMITS",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "dbo"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/buncombe_tax_permits.lib/buncombe_tax_permits.lib.json
+++ b/src/db/bedrock-db-data/data/assets/buncombe_tax_permits.lib/buncombe_tax_permits.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "buncombe_tax_permits.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "buncombe_tax_permits",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "buncombe_tax_permits.acc"

--- a/src/db/bedrock-db-data/data/assets/buncombe_tax_permits.pub/buncombe_tax_permits.pub.json
+++ b/src/db/bedrock-db-data/data/assets/buncombe_tax_permits.pub/buncombe_tax_permits.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "buncombe_tax_permits.pub",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "buncombe_tax_permits",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "buncombe_tax_permits.lib"

--- a/src/db/bedrock-db-data/data/assets/business_resources.goog/business_resources.goog.json
+++ b/src/db/bedrock-db-data/data/assets/business_resources.goog/business_resources.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "business_resources.goog",
+  "display_name": null,
   "description": "",
   "location": {
     "tab": "Sheet1",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1aTEJL7N3UI1CMObZmg9XicaCYL2USMnPIxh_esCZCos"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/business_resources.lib/business_resources.lib.json
+++ b/src/db/bedrock-db-data/data/assets/business_resources.lib/business_resources.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "business_resources.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "business_resources",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "business_resources.goog"

--- a/src/db/bedrock-db-data/data/assets/business_resources.pub/business_resources.pub.json
+++ b/src/db/bedrock-db-data/data/assets/business_resources.pub/business_resources.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "business_resources.pub",
+  "display_name": null,
   "description": "Planning and Development Business Resources-Public DB to be accessed from website",
   "location": {
     "tablename": "business_resources",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "business_resources.lib"

--- a/src/db/bedrock-db-data/data/assets/capital_projects_master.goog/capital_projects_master.goog.json
+++ b/src/db/bedrock-db-data/data/assets/capital_projects_master.goog/capital_projects_master.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "capital_projects_master.goog",
+  "display_name": null,
   "description": "Capital Projects General Project Information",
   "location": {
     "tab": "General Project Information",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1IepJrSjqbGK7UcTmFHqknNUD6Iyx6-3_zpj6qHprBgY"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/capital_projects_master.lib/capital_projects_master.lib.json
+++ b/src/db/bedrock-db-data/data/assets/capital_projects_master.lib/capital_projects_master.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "capital_projects_master.lib",
+  "display_name": null,
   "description": "Capital Projects General Project Information",
   "location": {
     "tablename": "capital_projects_master",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "capital_projects_master.goog"

--- a/src/db/bedrock-db-data/data/assets/capital_projects_master_categories.goog/capital_projects_master_categories.goog.json
+++ b/src/db/bedrock-db-data/data/assets/capital_projects_master_categories.goog/capital_projects_master_categories.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "capital_projects_master_categories.goog",
+  "display_name": null,
   "description": "Capital Projects Category List",
   "location": {
     "tab": "Categories",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1IepJrSjqbGK7UcTmFHqknNUD6Iyx6-3_zpj6qHprBgY"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/capital_projects_master_categories.lib/capital_projects_master_categories.lib.json
+++ b/src/db/bedrock-db-data/data/assets/capital_projects_master_categories.lib/capital_projects_master_categories.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "capital_projects_master_categories.lib",
+  "display_name": null,
   "description": "Capital Projects Category List",
   "location": {
     "tablename": "capital_projects_master_categories",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "capital_projects_master_categories.goog"

--- a/src/db/bedrock-db-data/data/assets/cigna.ftp/cigna.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/cigna.ftp/cigna.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "cigna.ftp",
+  "display_name": null,
   "description": "Uploaded staff data to Cigna",
   "location": {
     "path": "/Outbox/",
     "filename": "XO16000__xo10001i.77103.${YYYY}${MM}${DD}.txt",
     "connection": "cigna_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "cigna.s3"

--- a/src/db/bedrock-db-data/data/assets/cigna.s3/cigna.s3.json
+++ b/src/db/bedrock-db-data/data/assets/cigna.s3/cigna.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "cigna.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "cigna/",
     "filename": "XO16000__xo10001i.77103.${YYYY}${MM}${DD}.txt",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_cigna_feed_2.mun"

--- a/src/db/bedrock-db-data/data/assets/coa_active_jurisdictions.lib/coa_active_jurisdictions.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_active_jurisdictions.lib/coa_active_jurisdictions.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_active_jurisdictions.lib",
+  "display_name": null,
   "description": "Asheville corporate limits",
   "location": {
     "tablename": "coa_active_jurisdictions",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_active_jurisdictions.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_active_jurisdictions.slope/coa_active_jurisdictions.slope.json
+++ b/src/db/bedrock-db-data/data/assets/coa_active_jurisdictions.slope/coa_active_jurisdictions.slope.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_active_jurisdictions.slope",
+  "display_name": null,
   "description": "Asheville corporate limits",
   "location": {
     "tablename": "coa_active_jurisdictions",
     "connection": "pubrecdb1/steepslope/dbadmin",
     "schemaname": "public"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_active_jurisdictions.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_active_jurisdictions.wh/coa_active_jurisdictions.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_active_jurisdictions.wh/coa_active_jurisdictions.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_active_jurisdictions.wh",
+  "display_name": null,
   "description": "Asheville corporate limits",
   "location": {
     "tablename": "coa_active_jurisdictions",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_apd_public_incidents.lib/coa_apd_public_incidents.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_apd_public_incidents.lib/coa_apd_public_incidents.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_apd_public_incidents.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_apd_public_incidents",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_apd_public_incidents.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_apd_public_incidents.wh/coa_apd_public_incidents.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_apd_public_incidents.wh/coa_apd_public_incidents.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_apd_public_incidents.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_apd_public_incidents",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_asheville_neighborhoods.lib/coa_asheville_neighborhoods.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_asheville_neighborhoods.lib/coa_asheville_neighborhoods.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_asheville_neighborhoods.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_asheville_neighborhoods",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_asheville_neighborhoods.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_asheville_neighborhoods.wh/coa_asheville_neighborhoods.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_asheville_neighborhoods.wh/coa_asheville_neighborhoods.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_asheville_neighborhoods.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_asheville_neighborhoods",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_bc_address_master.lib/coa_bc_address_master.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_bc_address_master.lib/coa_bc_address_master.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_bc_address_master.lib",
+  "display_name": null,
   "description": "Master address table",
   "location": {
     "tablename": "coa_bc_address_master",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_districts_zoning.lib",

--- a/src/db/bedrock-db-data/data/assets/coa_blockgroups.lib/coa_blockgroups.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_blockgroups.lib/coa_blockgroups.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_blockgroups.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_blockgroups",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_blockgroups.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_blockgroups.wh/coa_blockgroups.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_blockgroups.wh/coa_blockgroups.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_blockgroups.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "census_2015_blockgroups",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_cip_project_lines.lib/coa_cip_project_lines.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_cip_project_lines.lib/coa_cip_project_lines.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_cip_project_lines.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_cip_project_lines",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_cip_project_lines.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_cip_project_lines.wh/coa_cip_project_lines.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_cip_project_lines.wh/coa_cip_project_lines.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_cip_project_lines.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_cip_project_lines",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_cip_project_points.lib/coa_cip_project_points.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_cip_project_points.lib/coa_cip_project_points.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_cip_project_points.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_cip_project_points",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_cip_project_points.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_cip_project_points.wh/coa_cip_project_points.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_cip_project_points.wh/coa_cip_project_points.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_cip_project_points.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_cip_project_points",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_cip_project_polygons.lib/coa_cip_project_polygons.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_cip_project_polygons.lib/coa_cip_project_polygons.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_cip_project_polygons.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_cip_project_polygons",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_cip_project_polygons.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_cip_project_polygons.wh/coa_cip_project_polygons.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_cip_project_polygons.wh/coa_cip_project_polygons.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_cip_project_polygons.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_cip_project_polygons",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_climate_justice_by_address.lib/coa_climate_justice_by_address.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_climate_justice_by_address.lib/coa_climate_justice_by_address.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_climate_justice_by_address.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_climate_justice_by_address",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_climate_justice_index.lib"

--- a/src/db/bedrock-db-data/data/assets/coa_climate_justice_index.lib/coa_climate_justice_index.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_climate_justice_index.lib/coa_climate_justice_index.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_climate_justice_index.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_climate_justice_index",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_climate_justice_index.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_climate_justice_index.wh/coa_climate_justice_index.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_climate_justice_index.wh/coa_climate_justice_index.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_climate_justice_index.wh",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "coa_climate_justice_index",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_computer_assets.goog/coa_computer_assets.goog.json
+++ b/src/db/bedrock-db-data/data/assets/coa_computer_assets.goog/coa_computer_assets.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "coa_computer_assets.goog",
+  "display_name": null,
   "description": "Computers on our network",
   "location": {
     "tab": "ComputerAssets",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1P9tdY7lawwoZXJmn09UgRMgH7JoauYG8h00MEkGzv8Q"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_computer_assets.lib"

--- a/src/db/bedrock-db-data/data/assets/coa_computer_assets.lib/coa_computer_assets.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_computer_assets.lib/coa_computer_assets.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_computer_assets.lib",
+  "display_name": null,
   "description": "Computers on our network",
   "location": {
     "tablename": "coa_computer_assets",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_districts_public_works.lib/coa_districts_public_works.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_districts_public_works.lib/coa_districts_public_works.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_districts_public_works.lib",
+  "display_name": null,
   "description": "Public works districts",
   "location": {
     "tablename": "coa_districts_public_works",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_districts_public_works.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_districts_public_works.wh/coa_districts_public_works.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_districts_public_works.wh/coa_districts_public_works.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_districts_public_works.wh",
+  "display_name": null,
   "description": "Public works districts",
   "location": {
     "tablename": "coa_districts_public_works",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_districts_water.lib/coa_districts_water.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_districts_water.lib/coa_districts_water.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_districts_water.lib",
+  "display_name": null,
   "description": "Asheville water districts",
   "location": {
     "tablename": "coa_districts_water",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_districts_water.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_districts_water.wh/coa_districts_water.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_districts_water.wh/coa_districts_water.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_districts_water.wh",
+  "display_name": null,
   "description": "Asheville water districts",
   "location": {
     "tablename": "coa_districts_water",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_districts_zoning.lib/coa_districts_zoning.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_districts_zoning.lib/coa_districts_zoning.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_districts_zoning.lib",
+  "display_name": null,
   "description": "Asheville zoning districts",
   "location": {
     "tablename": "coa_districts_zoning",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_districts_zoning.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_districts_zoning.wh/coa_districts_zoning.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_districts_zoning.wh/coa_districts_zoning.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_districts_zoning.wh",
+  "display_name": null,
   "description": "Asheville zoning districts",
   "location": {
     "tablename": "coa_districts_zoning",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_local_historic_landmarks.lib/coa_local_historic_landmarks.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_local_historic_landmarks.lib/coa_local_historic_landmarks.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_local_historic_landmarks.lib",
+  "display_name": null,
   "description": "coa_local_historic_landmarks",
   "location": {
     "tablename": "coa_local_historic_landmarks",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_local_historic_landmarks.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_local_historic_landmarks.wh/coa_local_historic_landmarks.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_local_historic_landmarks.wh/coa_local_historic_landmarks.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_local_historic_landmarks.wh",
+  "display_name": null,
   "description": "coa_local_historic_landmarks",
   "location": {
     "tablename": "coa_local_historic_landmarks",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_national_register_properties.lib/coa_national_register_properties.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_national_register_properties.lib/coa_national_register_properties.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_national_register_properties.lib",
+  "display_name": null,
   "description": "National register properties",
   "location": {
     "tablename": "coa_national_register_properties",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_national_register_properties.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_national_register_properties.wh/coa_national_register_properties.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_national_register_properties.wh/coa_national_register_properties.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_national_register_properties.wh",
+  "display_name": null,
   "description": "National register properties",
   "location": {
     "tablename": "coa_national_register_properties",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_street_maintenance.lib/coa_street_maintenance.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_street_maintenance.lib/coa_street_maintenance.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_street_maintenance.lib",
+  "display_name": null,
   "description": "Street Maintenance",
   "location": {
     "tablename": "coa_street_maintenance",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_street_maintenance.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_street_maintenance.wh/coa_street_maintenance.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_street_maintenance.wh/coa_street_maintenance.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_street_maintenance.wh",
+  "display_name": null,
   "description": "Street Maintenance",
   "location": {
     "tablename": "coa_street_maintenance",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_zip_code.lib/coa_zip_code.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_zip_code.lib/coa_zip_code.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_zip_code.lib",
+  "display_name": null,
   "description": "Asheville zip code areas",
   "location": {
     "tablename": "coa_zip_code",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_zip_code.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_zip_code.wh/coa_zip_code.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_zip_code.wh/coa_zip_code.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_zip_code.wh",
+  "display_name": null,
   "description": "Asheville zip code areas",
   "location": {
     "tablename": "coa_zip_code",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/coa_zoning_overlays.lib/coa_zoning_overlays.lib.json
+++ b/src/db/bedrock-db-data/data/assets/coa_zoning_overlays.lib/coa_zoning_overlays.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_zoning_overlays.lib",
+  "display_name": null,
   "description": "Asheville zoning overlays",
   "location": {
     "tablename": "coa_zoning_overlays",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "coa_zoning_overlays.wh"

--- a/src/db/bedrock-db-data/data/assets/coa_zoning_overlays.wh/coa_zoning_overlays.wh.json
+++ b/src/db/bedrock-db-data/data/assets/coa_zoning_overlays.wh/coa_zoning_overlays.wh.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "coa_zoning_overlays.wh",
+  "display_name": null,
   "description": "Asheville zoning overlays",
   "location": {
     "tablename": "coa_zoning_overlays",
     "connection": "gis-warehouse/coagiswarehouse/coagis",
     "schemaname": "coagis"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/compsych.ftp/compsych.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/compsych.ftp/compsych.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "compsych.ftp",
+  "display_name": null,
   "description": "Uploaded staff data to ComPsych(SunLife)",
   "location": {
     "path": "/",
     "filename": "compsych_CityofAsheville_${YYYY}${MM}${DD}.csv",
     "connection": "compsych_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "compsych.s3"

--- a/src/db/bedrock-db-data/data/assets/compsych.s3/compsych.s3.json
+++ b/src/db/bedrock-db-data/data/assets/compsych.s3/compsych.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "compsych.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "compsych/",
     "filename": "compsych_CityofAsheville_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "sunlife_eligibility.mun"

--- a/src/db/bedrock-db-data/data/assets/delta_dental.encrypted.s3/delta_dental.encrypted.s3.json
+++ b/src/db/bedrock-db-data/data/assets/delta_dental.encrypted.s3/delta_dental.encrypted.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "delta_dental.encrypted.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "delta_dental/",
     "filename": "deltadental_asheville_${YYYY}${MM}${DD}.txt.asc",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "delta_dental.s3"

--- a/src/db/bedrock-db-data/data/assets/delta_dental.ftp/delta_dental.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/delta_dental.ftp/delta_dental.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "delta_dental.ftp",
+  "display_name": null,
   "description": "Uploaded staff and customer data to Delta Dental",
   "location": {
     "path": "/in/",
     "filename": "deltadental_asheville_${YYYY}${MM}${DD}.txt.asc",
     "connection": "delta_dental_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "delta_dental.encrypted.s3"

--- a/src/db/bedrock-db-data/data/assets/delta_dental.s3/delta_dental.s3.json
+++ b/src/db/bedrock-db-data/data/assets/delta_dental.s3/delta_dental.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "delta_dental.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "delta_dental/",
     "filename": "deltadental_asheville_${YYYY}${MM}${DD}.txt",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_deltadental_feed.mun"

--- a/src/db/bedrock-db-data/data/assets/dsd_first_review_sla.acc/dsd_first_review_sla.acc.json
+++ b/src/db/bedrock-db-data/data/assets/dsd_first_review_sla.acc/dsd_first_review_sla.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "dsd_first_review_sla.acc",
+  "display_name": null,
   "description": "DSD first-review SLA performance",
   "location": {
     "tablename": "dsd_first_review_sla",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/dsd_first_review_sla.lib/dsd_first_review_sla.lib.json
+++ b/src/db/bedrock-db-data/data/assets/dsd_first_review_sla.lib/dsd_first_review_sla.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "dsd_first_review_sla.lib",
+  "display_name": null,
   "description": "DSD first-review SLA performance",
   "location": {
     "tablename": "dsd_first_review_sla",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "dsd_first_review_sla.acc"

--- a/src/db/bedrock-db-data/data/assets/eco_visio.api/eco_visio.api.json
+++ b/src/db/bedrock-db-data/data/assets/eco_visio.api/eco_visio.api.json
@@ -1,11 +1,14 @@
 {
   "asset_name": "eco_visio.api",
+  "display_name": null,
   "description": "Eco-Visio (bike counters) API",
   "location": {
     "connection": "eco_visio_api"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/employee_turnover_report.counts.goog/employee_turnover_report.counts.goog.json
+++ b/src/db/bedrock-db-data/data/assets/employee_turnover_report.counts.goog/employee_turnover_report.counts.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "employee_turnover_report.counts.goog",
+  "display_name": null,
   "description": "",
   "location": {
     "tab": "Counts",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1yE8pfp9nZ9nETDd2ypN4h6y8-m06giQ5O797ghBQHYc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_sensitive_snapshots.lib"

--- a/src/db/bedrock-db-data/data/assets/employee_turnover_report.terms.goog/employee_turnover_report.terms.goog.json
+++ b/src/db/bedrock-db-data/data/assets/employee_turnover_report.terms.goog/employee_turnover_report.terms.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "employee_turnover_report.terms.goog",
+  "display_name": null,
   "description": "",
   "location": {
     "tab": "Terminations",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1yE8pfp9nZ9nETDd2ypN4h6y8-m06giQ5O797ghBQHYc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_sensitive_snapshots.lib"

--- a/src/db/bedrock-db-data/data/assets/equity_students_completed.goog/equity_students_completed.goog.json
+++ b/src/db/bedrock-db-data/data/assets/equity_students_completed.goog/equity_students_completed.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "equity_students_completed.goog",
+  "display_name": null,
   "description": "List of MWBE vendors registered in Munis (not necessarily certified)",
   "location": {
     "tab": "Sheet1",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1xGD2jVSveuYjDLRc6Z8dlwGIA78LKJKxu0ck0Y7easg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "training_students.lib"

--- a/src/db/bedrock-db-data/data/assets/equity_students_completed.lib/equity_students_completed.lib.json
+++ b/src/db/bedrock-db-data/data/assets/equity_students_completed.lib/equity_students_completed.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "equity_students_completed.lib",
+  "display_name": null,
   "description": "List of MWBE vendors registered in Munis (not necessarily certified)",
   "location": {
     "tablename": "equity_students_completed",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "aux"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/everbridge.cust.ftp/everbridge.cust.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/everbridge.cust.ftp/everbridge.cust.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "everbridge.cust.ftp",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "/replace/",
     "filename": "avl.UB_Water_Customers_Everbridge.csv",
     "connection": "everbridge_cust_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "everbridge.cust.s3"

--- a/src/db/bedrock-db-data/data/assets/everbridge.cust.s3/everbridge.cust.s3.json
+++ b/src/db/bedrock-db-data/data/assets/everbridge.cust.s3/everbridge.cust.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "everbridge.cust.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "everbridge/",
     "filename": "avl.UB_Water_Customers_Everbridge.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "ub_water_customers_everbridge.mun"

--- a/src/db/bedrock-db-data/data/assets/everbridge.emp.ftp/everbridge.emp.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/everbridge.emp.ftp/everbridge.emp.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "everbridge.emp.ftp",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "/replace/",
     "filename": "avl.PR_City_Employees_Everbridge.csv",
     "connection": "everbridge_emp_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "everbridge.emp.s3"

--- a/src/db/bedrock-db-data/data/assets/everbridge.emp.s3/everbridge.emp.s3.json
+++ b/src/db/bedrock-db-data/data/assets/everbridge.emp.s3/everbridge.emp.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "everbridge.emp.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "everbridge/",
     "filename": "avl.PR_City_Employees_Everbridge.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_city_employees_everbridge.mun"

--- a/src/db/bedrock-db-data/data/assets/fire_pr_accrual_hours_balances.lib/fire_pr_accrual_hours_balances.lib.json
+++ b/src/db/bedrock-db-data/data/assets/fire_pr_accrual_hours_balances.lib/fire_pr_accrual_hours_balances.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "fire_pr_accrual_hours_balances.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "fire_pr_accrual_hours_balances",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/fire_pr_accrual_hours_balances.pub/fire_pr_accrual_hours_balances.pub.json
+++ b/src/db/bedrock-db-data/data/assets/fire_pr_accrual_hours_balances.pub/fire_pr_accrual_hours_balances.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "fire_pr_accrual_hours_balances.pub",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "fire_pr_accrual_hours_balances",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_accrual_hours_balances.lib",

--- a/src/db/bedrock-db-data/data/assets/general_ledger_parameters.lib/general_ledger_parameters.lib.json
+++ b/src/db/bedrock-db-data/data/assets/general_ledger_parameters.lib/general_ledger_parameters.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "general_ledger_parameters.lib",
+  "display_name": null,
   "description": "Various GL parameters, especially budget year",
   "location": {
     "tablename": "general_ledger_parameters",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "generalledgerparameters.mun"

--- a/src/db/bedrock-db-data/data/assets/generalledgerparameters.mun/generalledgerparameters.mun.json
+++ b/src/db/bedrock-db-data/data/assets/generalledgerparameters.mun/generalledgerparameters.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "generalledgerparameters.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "GeneralLedgerParameters",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "dbo"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/gl_budget.lib/gl_budget.lib.json
+++ b/src/db/bedrock-db-data/data/assets/gl_budget.lib/gl_budget.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "gl_budget.lib",
+  "display_name": null,
   "description": "Master budget table",
   "location": {
     "tablename": "gl_budget",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "gl_budget.mun"

--- a/src/db/bedrock-db-data/data/assets/gl_budget.mun/gl_budget.mun.json
+++ b/src/db/bedrock-db-data/data/assets/gl_budget.mun/gl_budget.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "gl_budget.mun",
+  "display_name": null,
   "description": "Master budget table",
   "location": {
     "tablename": "gl_budget",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/gl_master.lib/gl_master.lib.json
+++ b/src/db/bedrock-db-data/data/assets/gl_master.lib/gl_master.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "gl_master.lib",
+  "display_name": null,
   "description": "Master general ledger history",
   "location": {
     "tablename": "gl_master",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "gl_master.mun"

--- a/src/db/bedrock-db-data/data/assets/gl_master.mun/gl_master.mun.json
+++ b/src/db/bedrock-db-data/data/assets/gl_master.mun/gl_master.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "gl_master.mun",
+  "display_name": null,
   "description": "Master general ledger history",
   "location": {
     "tablename": "gl_master",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/google_info.lib/google_info.lib.json
+++ b/src/db/bedrock-db-data/data/assets/google_info.lib/google_info.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "google_info.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "google_info",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "google_info.mun"

--- a/src/db/bedrock-db-data/data/assets/google_info.mun/google_info.mun.json
+++ b/src/db/bedrock-db-data/data/assets/google_info.mun/google_info.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "google_info.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "Google_Info",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/google_info.pub/google_info.pub.json
+++ b/src/db/bedrock-db-data/data/assets/google_info.pub/google_info.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "google_info.pub",
+  "display_name": null,
   "description": "Google Group info",
   "location": {
     "tablename": "google_info",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "google_info.lib"

--- a/src/db/bedrock-db-data/data/assets/inspections.acc/inspections.acc.json
+++ b/src/db/bedrock-db-data/data/assets/inspections.acc/inspections.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "inspections.acc",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "inspections",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/inspections.lib/inspections.lib.json
+++ b/src/db/bedrock-db-data/data/assets/inspections.lib/inspections.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "inspections.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "inspections",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "inspections.acc"

--- a/src/db/bedrock-db-data/data/assets/inspections.pub/inspections.pub.json
+++ b/src/db/bedrock-db-data/data/assets/inspections.pub/inspections.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "inspections.pub",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "inspections",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "inspections.lib"

--- a/src/db/bedrock-db-data/data/assets/iran_divestment_approved_companies.lib/iran_divestment_approved_companies.lib.json
+++ b/src/db/bedrock-db-data/data/assets/iran_divestment_approved_companies.lib/iran_divestment_approved_companies.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "iran_divestment_approved_companies.lib",
+  "display_name": null,
   "description": "Non-Iranian Companies with names similar to Iranian Companies",
   "location": {
     "tablename": "iran_divestment_approved_companies",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "iran_divestment_companies.approved.goog"

--- a/src/db/bedrock-db-data/data/assets/iran_divestment_companies.approved.goog/iran_divestment_companies.approved.goog.json
+++ b/src/db/bedrock-db-data/data/assets/iran_divestment_companies.approved.goog/iran_divestment_companies.approved.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "iran_divestment_companies.approved.goog",
+  "display_name": null,
   "description": "",
   "location": {
     "tab": "Approved Companies",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1FOmrFm5afRc_XqTeF2T-ilWtZDIYzdqKiZlPX129IQA"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/iran_divestment_companies.goog/iran_divestment_companies.goog.json
+++ b/src/db/bedrock-db-data/data/assets/iran_divestment_companies.goog/iran_divestment_companies.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "iran_divestment_companies.goog",
+  "display_name": null,
   "description": "",
   "location": {
     "tab": "Bad Actors",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1FOmrFm5afRc_XqTeF2T-ilWtZDIYzdqKiZlPX129IQA"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/iran_divestment_restricted_companies.lib/iran_divestment_restricted_companies.lib.json
+++ b/src/db/bedrock-db-data/data/assets/iran_divestment_restricted_companies.lib/iran_divestment_restricted_companies.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "iran_divestment_restricted_companies.lib",
+  "display_name": null,
   "description": "Iranian Companies we are forbidden to work with",
   "location": {
     "tablename": "iran_divestment_restricted_companies",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "iran_divestment_companies.goog"

--- a/src/db/bedrock-db-data/data/assets/maint_Beneficial_Fill_Sites.maint/maint_Beneficial_Fill_Sites.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Beneficial_Fill_Sites.maint/maint_Beneficial_Fill_Sites.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Beneficial_Fill_Sites.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Beneficial Fill Sites",
   "location": {
     "tab": "Beneficial Fill Sites",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Bingham_Road.maint/maint_Bingham_Road.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Bingham_Road.maint/maint_Bingham_Road.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Bingham_Road.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Bingham_Road",
   "location": {
     "tab": "Bingham Road",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Comm_Towers.maint/maint_Comm_Towers.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Comm_Towers.maint/maint_Comm_Towers.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Comm_Towers.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Comm_Towers",
   "location": {
     "tab": "Comm Towers",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Fire_Stations.maint/maint_Fire_Stations.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Fire_Stations.maint/maint_Fire_Stations.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Fire_Stations.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Fire Stations",
   "location": {
     "tab": "Fire Stations",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Fuel_Stations.maint/maint_Fuel_Stations.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Fuel_Stations.maint/maint_Fuel_Stations.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Fuel_Stations.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Fuel Stations",
   "location": {
     "tab": "Fuel Stations",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_General_Facility.maint/maint_General_Facility.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_General_Facility.maint/maint_General_Facility.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_General_Facility.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Administration",
   "location": {
     "tab": "General Facility",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Greenways_and_Trails.maint/maint_Greenways_and_Trails.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Greenways_and_Trails.maint/maint_Greenways_and_Trails.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Greenways_and_Trails.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Greenways & Trails",
   "location": {
     "tab": "Greenways & Trails",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Harrahs-TWA.maint/maint_Harrahs-TWA.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Harrahs-TWA.maint/maint_Harrahs-TWA.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Harrahs-TWA.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Harrahs-TWA",
   "location": {
     "tab": "Harrah's/TWA",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Parking_Garages.maint/maint_Parking_Garages.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Parking_Garages.maint/maint_Parking_Garages.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Parking_Garages.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Parking_Garages",
   "location": {
     "tab": "Parking Garages",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Parks_Plazas_Outdoor_Rec_Spaces.maint/maint_Parks_Plazas_Outdoor_Rec_Spaces.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Parks_Plazas_Outdoor_Rec_Spaces.maint/maint_Parks_Plazas_Outdoor_Rec_Spaces.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Parks_Plazas_Outdoor_Rec_Spaces.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Parks/Plazas/Outdoor Rec Spaces",
   "location": {
     "tab": "Parks/Plazas/Outdoor Rec Spaces",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Pools.maint/maint_Pools.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Pools.maint/maint_Pools.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Pools.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Pools",
   "location": {
     "tab": "Pools",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Public_Art-Urban_Trail.maint/maint_Public_Art-Urban_Trail.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Public_Art-Urban_Trail.maint/maint_Public_Art-Urban_Trail.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Public_Art-Urban_Trail.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Public_Art-Urban_Trail",
   "location": {
     "tab": "Public Art/Urban Trail",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Pump_Houses.maint/maint_Pump_Houses.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Pump_Houses.maint/maint_Pump_Houses.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Pump_Houses.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Pump_Houses",
   "location": {
     "tab": "Pump Houses",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Restrooms-Concessions.maint.json/maint_Restrooms-Concessions.maint.json.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Restrooms-Concessions.maint.json/maint_Restrooms-Concessions.maint.json.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Restrooms-Concessions.maint.json",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Restrooms-Concessions",
   "location": {
     "tab": "Restrooms/Concessions",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Right_of_Way.maint/maint_Right_of_Way.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Right_of_Way.maint/maint_Right_of_Way.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Right_of_Way.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Right of Way",
   "location": {
     "tab": "Right of Way",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Surface_Parking_Lots.maint/maint_Surface_Parking_Lots.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Surface_Parking_Lots.maint/maint_Surface_Parking_Lots.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Surface_Parking_Lots.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Surface Parking Lots",
   "location": {
     "tab": "Surface Parking Lots",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Vacant_Lots.maint/maint_Vacant_Lots.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Vacant_Lots.maint/maint_Vacant_Lots.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Vacant_Lots.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Vacant Lots",
   "location": {
     "tab": "Vacant Lots",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maint_Water_Treatment_Plants.maint/maint_Water_Treatment_Plants.maint.json
+++ b/src/db/bedrock-db-data/data/assets/maint_Water_Treatment_Plants.maint/maint_Water_Treatment_Plants.maint.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maint_Water_Treatment_Plants.maint",
+  "display_name": null,
   "description": "Maintenance Responsibilities: Water_Treatment_Plants",
   "location": {
     "tab": "Water Treatment Plants",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/maintenance_buildings.goog/maintenance_buildings.goog.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_buildings.goog/maintenance_buildings.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "maintenance_buildings.goog",
+  "display_name": null,
   "description": "City Property Maintenance Responsibility Building List",
   "location": {
     "tab": "Building Classification",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/maintenance_buildings.lib/maintenance_buildings.lib.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_buildings.lib/maintenance_buildings.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_buildings.lib",
+  "display_name": null,
   "description": "City Property Maintenance Responsibility Building List",
   "location": {
     "tablename": "maintenance_buildings",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "maintenance_buildings.goog"

--- a/src/db/bedrock-db-data/data/assets/maintenance_buildings.pub/maintenance_buildings.pub.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_buildings.pub/maintenance_buildings.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_buildings.pub",
+  "display_name": null,
   "description": "City Facility Maintenance Responsibilties Buildings",
   "location": {
     "tablename": "maintenance_buildings",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "maintenance_buildings.lib"

--- a/src/db/bedrock-db-data/data/assets/maintenance_responsibilities.lib/maintenance_responsibilities.lib.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_responsibilities.lib/maintenance_responsibilities.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_responsibilities.lib",
+  "display_name": null,
   "description": "City Property Maintenance Responsibilities",
   "location": {
     "tablename": "maintenance_responsibilities",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "#maintenance_responsibilities"

--- a/src/db/bedrock-db-data/data/assets/maintenance_responsibilities.pub/maintenance_responsibilities.pub.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_responsibilities.pub/maintenance_responsibilities.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_responsibilities.pub",
+  "display_name": null,
   "description": "City Facility Maintenance Responsibilties",
   "location": {
     "tablename": "maintenance_responsibilities",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "maintenance_responsibilities.lib"

--- a/src/db/bedrock-db-data/data/assets/maintenance_responsibilities_temp.lib/maintenance_responsibilities_temp.lib.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_responsibilities_temp.lib/maintenance_responsibilities_temp.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_responsibilities_temp.lib",
+  "display_name": null,
   "description": "City Property Maintenance Responsibilities-Temp Table",
   "location": {
     "tablename": "maintenance_responsibilities_temp",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "temp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/maintenance_tasktypes.goog/maintenance_tasktypes.goog.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_tasktypes.goog/maintenance_tasktypes.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "maintenance_tasktypes.goog",
+  "display_name": null,
   "description": "City Facility Maintenance: Task Types-Buildings",
   "location": {
     "tab": "SUMMARY",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "16rZUoAlISFIAmvcnSMHmhaE0qObj2OMpHQX3ddRoEwg"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/maintenance_tasktypes.lib/maintenance_tasktypes.lib.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_tasktypes.lib/maintenance_tasktypes.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_tasktypes.lib",
+  "display_name": null,
   "description": "City Facility Maintenance: Task Types",
   "location": {
     "tablename": "maintenance_tasktypes",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "maintenance_tasktypes.goog"

--- a/src/db/bedrock-db-data/data/assets/maintenance_tasktypes.pub/maintenance_tasktypes.pub.json
+++ b/src/db/bedrock-db-data/data/assets/maintenance_tasktypes.pub/maintenance_tasktypes.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "maintenance_tasktypes.pub",
+  "display_name": null,
   "description": "City Facility Maintenance: Task Types",
   "location": {
     "tablename": "maintenance_tasktypes",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "maintenance_tasktypes.lib"

--- a/src/db/bedrock-db-data/data/assets/mwbe_vendors_by_commodity.mun/mwbe_vendors_by_commodity.mun.json
+++ b/src/db/bedrock-db-data/data/assets/mwbe_vendors_by_commodity.mun/mwbe_vendors_by_commodity.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "mwbe_vendors_by_commodity.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "mwbe_vendors_by_commodity",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/mwbe_vendors_by_commodity_non_aggregated.mun/mwbe_vendors_by_commodity_non_aggregated.mun.json
+++ b/src/db/bedrock-db-data/data/assets/mwbe_vendors_by_commodity_non_aggregated.mun/mwbe_vendors_by_commodity_non_aggregated.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "mwbe_vendors_by_commodity_non_aggregated.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "mwbe_vendors_by_commodity_non_aggregated",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/nc_benchmarks.lib/nc_benchmarks.lib.json
+++ b/src/db/bedrock-db-data/data/assets/nc_benchmarks.lib/nc_benchmarks.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "nc_benchmarks.lib",
+  "display_name": null,
   "description": "North Carolina Benchmarks",
   "location": {
     "tablename": "nc_benchmarks",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "#nc_benchmarks"

--- a/src/db/bedrock-db-data/data/assets/nc_benchmarks.pub/nc_benchmarks.pub.json
+++ b/src/db/bedrock-db-data/data/assets/nc_benchmarks.pub/nc_benchmarks.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "nc_benchmarks.pub",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "nc_benchmarks",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "nc_benchmarks.lib"

--- a/src/db/bedrock-db-data/data/assets/nc_benchmarks_temp.lib/nc_benchmarks_temp.lib.json
+++ b/src/db/bedrock-db-data/data/assets/nc_benchmarks_temp.lib/nc_benchmarks_temp.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "nc_benchmarks_temp.lib",
+  "display_name": null,
   "description": "North Carolina Benchmarks-Temp Table",
   "location": {
     "tablename": "nc_benchmarks_temp",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "temp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/paymentus.empty_control_file.lib/paymentus.empty_control_file.lib.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus.empty_control_file.lib/paymentus.empty_control_file.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus.empty_control_file.lib",
+  "display_name": null,
   "description": "Paymentus Uploads require an empty file to be uploaded after data is sent to let them know upload is ready",
   "location": {
     "tablename": "emptydata",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/paymentus_cif.ctl.ftp/paymentus_cif.ctl.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_cif.ctl.ftp/paymentus_cif.ctl.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_cif.ctl.ftp",
+  "display_name": null,
   "description": "paymentus_cif control file",
   "location": {
     "path": "/input/",
     "filename": "CIF${YYYY}${MM}${DD}.ctl",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_cif.ctl.s3"

--- a/src/db/bedrock-db-data/data/assets/paymentus_cif.ctl.s3/paymentus_cif.ctl.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_cif.ctl.s3/paymentus_cif.ctl.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_cif.ctl.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "paymentus/",
     "filename": "CIF${YYYY}${MM}${DD}.ctl",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus.empty_control_file.lib"

--- a/src/db/bedrock-db-data/data/assets/paymentus_cif.ftp/paymentus_cif.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_cif.ftp/paymentus_cif.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_cif.ftp",
+  "display_name": null,
   "description": "Paymentus CIF",
   "location": {
     "path": "/input/",
     "filename": "CIF${YYYY}${MM}${DD}.csv",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_cif.s3"

--- a/src/db/bedrock-db-data/data/assets/paymentus_cif.mun/paymentus_cif.mun.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_cif.mun/paymentus_cif.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_cif.mun",
+  "display_name": null,
   "description": "Paymentus CIF",
   "location": {
     "tablename": "ub_pm_cif_file",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/paymentus_cif.s3/paymentus_cif.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_cif.s3/paymentus_cif.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_cif.s3",
+  "display_name": null,
   "description": "Paymentus CIF",
   "location": {
     "path": "paymentus/",
     "filename": "CIF${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_cif.mun"

--- a/src/db/bedrock-db-data/data/assets/paymentus_paper_suppression.ftp/paymentus_paper_suppression.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_paper_suppression.ftp/paymentus_paper_suppression.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_paper_suppression.ftp",
+  "display_name": null,
   "description": "Downloaded Paymentus list of people not to send paper bills to",
   "location": {
     "path": "/output/${YYYY}${MM}${DD}/",
     "filename": "ashv-paper-suppression-${YYYY}${MM}${DD}.csv",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/paymentus_paper_suppression.mun/paymentus_paper_suppression.mun.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_paper_suppression.mun/paymentus_paper_suppression.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_paper_suppression.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "Paymentus_Paper_Suppression_Table",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_paper_suppression.s3"

--- a/src/db/bedrock-db-data/data/assets/paymentus_paper_suppression.s3/paymentus_paper_suppression.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_paper_suppression.s3/paymentus_paper_suppression.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_paper_suppression.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "paymentus/",
     "filename": "ashv-paper-suppression-${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_paper_suppression.ftp"

--- a/src/db/bedrock-db-data/data/assets/paymentus_payment_history.ctl.ftp/paymentus_payment_history.ctl.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_payment_history.ctl.ftp/paymentus_payment_history.ctl.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_payment_history.ctl.ftp",
+  "display_name": null,
   "description": "paymentus_payment_history control file",
   "location": {
     "path": "/payment-history/",
     "filename": "Payment${YYYY}${MM}${DD}.ctl",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_payment_history.ctl.s3"

--- a/src/db/bedrock-db-data/data/assets/paymentus_payment_history.ctl.s3/paymentus_payment_history.ctl.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_payment_history.ctl.s3/paymentus_payment_history.ctl.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_payment_history.ctl.s3",
+  "display_name": null,
   "description": "paymentus_payment_history control file",
   "location": {
     "path": "paymentus/",
     "filename": "Payment${YYYY}${MM}${DD}.ctl",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus.empty_control_file.lib"

--- a/src/db/bedrock-db-data/data/assets/paymentus_payment_history.ftp/paymentus_payment_history.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_payment_history.ftp/paymentus_payment_history.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_payment_history.ftp",
+  "display_name": null,
   "description": "Paymentus Payment History",
   "location": {
     "path": "/payment-history/",
     "filename": "Payment${YYYY}${MM}${DD}.csv",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_payment_history.s3",

--- a/src/db/bedrock-db-data/data/assets/paymentus_payment_history.mun/paymentus_payment_history.mun.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_payment_history.mun/paymentus_payment_history.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_payment_history.mun",
+  "display_name": null,
   "description": "Paymentus Payment History",
   "location": {
     "tablename": "ub_pm_payment_history_loader_today_no_ivr",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/paymentus_payment_history.s3/paymentus_payment_history.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_payment_history.s3/paymentus_payment_history.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_payment_history.s3",
+  "display_name": null,
   "description": "Paymentus Payment History",
   "location": {
     "path": "paymentus/",
     "filename": "Payment${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_payment_history.mun"

--- a/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.ctl.ftp/paymentus_suspended_accounts.ctl.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.ctl.ftp/paymentus_suspended_accounts.ctl.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_suspended_accounts.ctl.ftp",
+  "display_name": null,
   "description": "paymentus_suspended_accounts control file",
   "location": {
     "path": "/suspended/",
     "filename": "Susp${YYYY}${MM}${DD}.ctl",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_suspended_accounts.ctl.s3"

--- a/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.ctl.s3/paymentus_suspended_accounts.ctl.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.ctl.s3/paymentus_suspended_accounts.ctl.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_suspended_accounts.ctl.s3",
+  "display_name": null,
   "description": "paymentus_suspended_accounts control file",
   "location": {
     "path": "paymentus/",
     "filename": "Susp${YYYY}${MM}${DD}.ctl",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus.empty_control_file.lib"

--- a/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.ftp/paymentus_suspended_accounts.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.ftp/paymentus_suspended_accounts.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_suspended_accounts.ftp",
+  "display_name": null,
   "description": "Paymentus Suspended Accounts",
   "location": {
     "path": "/suspended/",
     "filename": "Susp${YYYY}${MM}${DD}.csv",
     "connection": "paymentus_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_suspended_accounts.s3",

--- a/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.mun/paymentus_suspended_accounts.mun.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.mun/paymentus_suspended_accounts.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_suspended_accounts.mun",
+  "display_name": null,
   "description": "Paymentus Suspended Accounts",
   "location": {
     "tablename": "ub_pm_suspended_accounts",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.s3/paymentus_suspended_accounts.s3.json
+++ b/src/db/bedrock-db-data/data/assets/paymentus_suspended_accounts.s3/paymentus_suspended_accounts.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "paymentus_suspended_accounts.s3",
+  "display_name": null,
   "description": "Paymentus Suspended Accounts",
   "location": {
     "path": "paymentus/",
     "filename": "Susp${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "paymentus_suspended_accounts.mun"

--- a/src/db/bedrock-db-data/data/assets/pcard_statement_status_history.lib/pcard_statement_status_history.lib.json
+++ b/src/db/bedrock-db-data/data/assets/pcard_statement_status_history.lib/pcard_statement_status_history.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pcard_statement_status_history.lib",
+  "display_name": null,
   "description": "PCard transactions and status",
   "location": {
     "tablename": "pcard_statement_status_history",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pcard_statement_status_history.mun"

--- a/src/db/bedrock-db-data/data/assets/pcard_statement_status_history.mun/pcard_statement_status_history.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pcard_statement_status_history.mun/pcard_statement_status_history.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pcard_statement_status_history.mun",
+  "display_name": null,
   "description": "PCard transactions and status",
   "location": {
     "tablename": "pcard_statement_status_history",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pcard_transaction.lib/pcard_transaction.lib.json
+++ b/src/db/bedrock-db-data/data/assets/pcard_transaction.lib/pcard_transaction.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pcard_transaction.lib",
+  "display_name": null,
   "description": "PCard transaction",
   "location": {
     "tablename": "pcard_transaction",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pcard_transaction.mun"

--- a/src/db/bedrock-db-data/data/assets/pcard_transaction.mun/pcard_transaction.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pcard_transaction.mun/pcard_transaction.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pcard_transaction.mun",
+  "display_name": null,
   "description": "PCard transaction",
   "location": {
     "tablename": "pcard_transaction",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_comments.acc/permit_comments.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_comments.acc/permit_comments.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_comments.acc",
+  "display_name": null,
   "description": "Permit comments data",
   "location": {
     "tablename": "permit_comments",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_comments.lib/permit_comments.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_comments.lib/permit_comments.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_comments.lib",
+  "display_name": null,
   "description": "Permit comments data",
   "location": {
     "tablename": "permit_comments",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_comments.acc"

--- a/src/db/bedrock-db-data/data/assets/permit_comments.pub/permit_comments.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permit_comments.pub/permit_comments.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_comments.pub",
+  "display_name": null,
   "description": "Permit comments data",
   "location": {
     "tablename": "permit_comments",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_comments.lib"

--- a/src/db/bedrock-db-data/data/assets/permit_contacts.acc/permit_contacts.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_contacts.acc/permit_contacts.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_contacts.acc",
+  "display_name": null,
   "description": "Contacts associated with permits",
   "location": {
     "tablename": "permit_contacts",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_contacts.lib/permit_contacts.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_contacts.lib/permit_contacts.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_contacts.lib",
+  "display_name": null,
   "description": "Contacts associated with permits",
   "location": {
     "tablename": "permit_contacts",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_contacts.acc"

--- a/src/db/bedrock-db-data/data/assets/permit_contacts.pub/permit_contacts.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permit_contacts.pub/permit_contacts.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_contacts.pub",
+  "display_name": null,
   "description": "Contacts associated with permits",
   "location": {
     "tablename": "permit_contacts",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_contacts.lib"

--- a/src/db/bedrock-db-data/data/assets/permit_contractors.acc/permit_contractors.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_contractors.acc/permit_contractors.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_contractors.acc",
+  "display_name": null,
   "description": "Permit contractors data",
   "location": {
     "tablename": "permit_contractors",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_contractors.lib/permit_contractors.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_contractors.lib/permit_contractors.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_contractors.lib",
+  "display_name": null,
   "description": "Permit contractors data",
   "location": {
     "tablename": "permit_contractors",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_contractors.acc"

--- a/src/db/bedrock-db-data/data/assets/permit_contractors.pub/permit_contractors.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permit_contractors.pub/permit_contractors.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_contractors.pub",
+  "display_name": null,
   "description": "Permit contractors data",
   "location": {
     "tablename": "permit_contractors",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_contractors.lib"

--- a/src/db/bedrock-db-data/data/assets/permit_custom_fields.acc/permit_custom_fields.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_custom_fields.acc/permit_custom_fields.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_custom_fields.acc",
+  "display_name": null,
   "description": "Permit custom fields data ADD THIS depends BACK!!!! \"permits\"",
   "location": {
     "tablename": "permit_custom_fields",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_custom_fields.lib/permit_custom_fields.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_custom_fields.lib/permit_custom_fields.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_custom_fields.lib",
+  "display_name": null,
   "description": "Permit custom fields data ADD THIS depends BACK!!!! \"permits\"",
   "location": {
     "tablename": "permit_custom_fields",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_custom_fields.acc",

--- a/src/db/bedrock-db-data/data/assets/permit_custom_fields.pub/permit_custom_fields.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permit_custom_fields.pub/permit_custom_fields.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_custom_fields.pub",
+  "display_name": null,
   "description": "Permit custom fields data ADD THIS depends BACK!!!! \"permits\"",
   "location": {
     "tablename": "permit_custom_fields",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_custom_fields.lib"

--- a/src/db/bedrock-db-data/data/assets/permit_owners.acc/permit_owners.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_owners.acc/permit_owners.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_owners.acc",
+  "display_name": null,
   "description": "Owners associated with permits",
   "location": {
     "tablename": "permit_owners",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_owners.lib/permit_owners.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_owners.lib/permit_owners.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_owners.lib",
+  "display_name": null,
   "description": "Owners associated with permits",
   "location": {
     "tablename": "permit_owners",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_owners.acc"

--- a/src/db/bedrock-db-data/data/assets/permit_owners.pub/permit_owners.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permit_owners.pub/permit_owners.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_owners.pub",
+  "display_name": null,
   "description": "Owners associated with permits",
   "location": {
     "tablename": "permit_owners",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_owners.lib"

--- a/src/db/bedrock-db-data/data/assets/permit_review_times.acc/permit_review_times.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_review_times.acc/permit_review_times.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_review_times.acc",
+  "display_name": null,
   "description": "Count days to review permits",
   "location": {
     "tablename": "permit_review_times",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "dbo"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_review_times.lib/permit_review_times.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_review_times.lib/permit_review_times.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_review_times.lib",
+  "display_name": null,
   "description": "Count days to review permits",
   "location": {
     "tablename": "permit_review_times",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_review_times.acc"

--- a/src/db/bedrock-db-data/data/assets/permit_tasks.acc/permit_tasks.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permit_tasks.acc/permit_tasks.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_tasks.acc",
+  "display_name": null,
   "description": "Permit tasks data",
   "location": {
     "tablename": "permit_tasks",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permit_tasks.lib/permit_tasks.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permit_tasks.lib/permit_tasks.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_tasks.lib",
+  "display_name": null,
   "description": "Permit tasks data",
   "location": {
     "tablename": "permit_tasks",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_tasks.acc"

--- a/src/db/bedrock-db-data/data/assets/permit_tasks.pub/permit_tasks.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permit_tasks.pub/permit_tasks.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permit_tasks.pub",
+  "display_name": null,
   "description": "Permit tasks data",
   "location": {
     "tablename": "permit_tasks",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permit_tasks.lib"

--- a/src/db/bedrock-db-data/data/assets/permits.acc/permits.acc.json
+++ b/src/db/bedrock-db-data/data/assets/permits.acc/permits.acc.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permits.acc",
+  "display_name": null,
   "description": "Permits data",
   "location": {
     "tablename": "permits",
     "connection": "coa-acceladb/accela/mssqlgisadmin",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/permits.lib/permits.lib.json
+++ b/src/db/bedrock-db-data/data/assets/permits.lib/permits.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permits.lib",
+  "display_name": null,
   "description": "Permits data",
   "location": {
     "tablename": "permits",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permits.acc"

--- a/src/db/bedrock-db-data/data/assets/permits.pub/permits.pub.json
+++ b/src/db/bedrock-db-data/data/assets/permits.pub/permits.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "permits.pub",
+  "display_name": null,
   "description": "Permits data",
   "location": {
     "tablename": "permits",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "bc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "permits.lib"

--- a/src/db/bedrock-db-data/data/assets/pr_accrual_hours_balances.lib/pr_accrual_hours_balances.lib.json
+++ b/src/db/bedrock-db-data/data/assets/pr_accrual_hours_balances.lib/pr_accrual_hours_balances.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_accrual_hours_balances.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "pr_accrual_hours_balances",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_accrual_hours_balances.mun"

--- a/src/db/bedrock-db-data/data/assets/pr_accrual_hours_balances.mun/pr_accrual_hours_balances.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_accrual_hours_balances.mun/pr_accrual_hours_balances.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_accrual_hours_balances.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "pr_accrual_hours_balances",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_aetna_feed.mun/pr_aetna_feed.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_aetna_feed.mun/pr_aetna_feed.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_aetna_feed.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "PR_AETNA_Feed_2023",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_allstate_feed.mun/pr_allstate_feed.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_allstate_feed.mun/pr_allstate_feed.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_allstate_feed.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "PR_ALLSTATE_Feed",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_arag_feed.mun/pr_arag_feed.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_arag_feed.mun/pr_arag_feed.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_arag_feed.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "PR_ARAG_Feed",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_cigna_feed_2.mun/pr_cigna_feed_2.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_cigna_feed_2.mun/pr_cigna_feed_2.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_cigna_feed_2.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "PR_CIGNA_Feed_2023",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_city_employees_everbridge.mun/pr_city_employees_everbridge.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_city_employees_everbridge.mun/pr_city_employees_everbridge.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_city_employees_everbridge.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "PR_City_Employees_Everbridge",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_deltadental_feed.mun/pr_deltadental_feed.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_deltadental_feed.mun/pr_deltadental_feed.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_deltadental_feed.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "PR_DeltaDental_Feed_2023",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_employee_info.lib/pr_employee_info.lib.json
+++ b/src/db/bedrock-db-data/data/assets/pr_employee_info.lib/pr_employee_info.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_employee_info.lib",
+  "display_name": null,
   "description": "Basic information for employees",
   "location": {
     "tablename": "pr_employee_info",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_employee_info.mun"

--- a/src/db/bedrock-db-data/data/assets/pr_employee_info.mun/pr_employee_info.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_employee_info.mun/pr_employee_info.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_employee_info.mun",
+  "display_name": null,
   "description": "Basic information for employees",
   "location": {
     "tablename": "pr_employee_info",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/pr_employee_info_safety.mun/pr_employee_info_safety.mun.json
+++ b/src/db/bedrock-db-data/data/assets/pr_employee_info_safety.mun/pr_employee_info_safety.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "pr_employee_info_safety.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "pr_employee_info_safety",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/safetyskills.ftp/safetyskills.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/safetyskills.ftp/safetyskills.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "safetyskills.ftp",
+  "display_name": null,
   "description": "Uploaded staff data to Safety Skills",
   "location": {
     "path": "/35408/",
     "filename": "users.csv",
     "connection": "safetyskills_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "safetyskills.s3"

--- a/src/db/bedrock-db-data/data/assets/safetyskills.s3/safetyskills.s3.json
+++ b/src/db/bedrock-db-data/data/assets/safetyskills.s3/safetyskills.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "safetyskills.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "safetyskills/",
     "filename": "users${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "pr_employee_info_safety.mun"

--- a/src/db/bedrock-db-data/data/assets/sog_billed_water_volume.ncb/sog_billed_water_volume.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_billed_water_volume.ncb/sog_billed_water_volume.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_billed_water_volume.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: Billed Water Volume",
   "location": {
     "tab": "billed_water_volume",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_filter_run_time.ncb/sog_filter_run_time.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_filter_run_time.ncb/sog_filter_run_time.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_filter_run_time.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: Filter Run Time",
   "location": {
     "tab": "filter_run_time",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_filter_run_volume.ncb/sog_filter_run_volume.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_filter_run_volume.ncb/sog_filter_run_volume.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_filter_run_volume.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: Filter Run Volume",
   "location": {
     "tab": "filter_run_volume",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_finished_water_volume.ncb/sog_finished_water_volume.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_finished_water_volume.ncb/sog_finished_water_volume.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_finished_water_volume.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: Finished Water Volume",
   "location": {
     "tab": "finished_water_volume",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_max_water_turbidity.ncb/sog_max_water_turbidity.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_max_water_turbidity.ncb/sog_max_water_turbidity.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_max_water_turbidity.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: max_water_turbidity",
   "location": {
     "tab": "max_water_turbidity",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_other_water_meter_count.ncb/sog_other_water_meter_count.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_other_water_meter_count.ncb/sog_other_water_meter_count.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_other_water_meter_count.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: Billed Water Volume",
   "location": {
     "tab": "other_water_meter_count",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_pump_station_count.ncb/sog_pump_station_count.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_pump_station_count.ncb/sog_pump_station_count.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_pump_station_count.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: pump_station_count",
   "location": {
     "tab": "pump_station_count",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_purchased_water_volume.ncb/sog_purchased_water_volume.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_purchased_water_volume.ncb/sog_purchased_water_volume.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_purchased_water_volume.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: Purchased Water Volume",
   "location": {
     "tab": "purchased_water_volume",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_residential_water_meter_count.ncb/sog_residential_water_meter_count.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_residential_water_meter_count.ncb/sog_residential_water_meter_count.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_residential_water_meter_count.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: residential_water_meter_count",
   "location": {
     "tab": "residential_water_meter_count",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_average_turbidity.ncb/sog_water_average_turbidity.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_average_turbidity.ncb/sog_water_average_turbidity.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_average_turbidity.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_average_turbidity",
   "location": {
     "tab": "water_average_turbidity",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_breaks_leaks_count.ncb/sog_water_breaks_leaks_count.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_breaks_leaks_count.ncb/sog_water_breaks_leaks_count.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_breaks_leaks_count.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_breaks_leaks_count",
   "location": {
     "tab": "water_breaks_leaks_count",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_chlorine.ncb/sog_water_chlorine.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_chlorine.ncb/sog_water_chlorine.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_chlorine.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_chlorine",
   "location": {
     "tab": "water_chlorine",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_coliform.ncb/sog_water_coliform.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_coliform.ncb/sog_water_coliform.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_coliform.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_coliform",
   "location": {
     "tab": "water_coliform",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_fluoride.ncb/sog_water_fluoride.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_fluoride.ncb/sog_water_fluoride.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_fluoride.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_fluoride",
   "location": {
     "tab": "water_fluoride",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_hardness.ncb/sog_water_hardness.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_hardness.ncb/sog_water_hardness.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_hardness.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_hardness",
   "location": {
     "tab": "water_hardness",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_iron.ncb/sog_water_iron.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_iron.ncb/sog_water_iron.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_iron.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_iron",
   "location": {
     "tab": "water_iron",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_ph.ncb/sog_water_ph.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_ph.ncb/sog_water_ph.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_ph.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_ph",
   "location": {
     "tab": "water_ph",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_pipe_inch_diameter_miles.ncb/sog_water_pipe_inch_diameter_miles.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_pipe_inch_diameter_miles.ncb/sog_water_pipe_inch_diameter_miles.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_pipe_inch_diameter_miles.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_pipe_inch_diameter_miles",
   "location": {
     "tab": "water_pipe_inch_diameter_miles",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_pipe_miles.ncb/sog_water_pipe_miles.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_pipe_miles.ncb/sog_water_pipe_miles.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_pipe_miles.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_pipe_miles",
   "location": {
     "tab": "water_pipe_miles",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_plant_count.ncb/sog_water_plant_count.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_plant_count.ncb/sog_water_plant_count.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_plant_count.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_plant_count",
   "location": {
     "tab": "water_plant_count",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_regulatory_violations_count.ncb/sog_water_regulatory_violations_count.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_regulatory_violations_count.ncb/sog_water_regulatory_violations_count.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_regulatory_violations_count.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_regulatory_violations_count",
   "location": {
     "tab": "water_regulatory_violations_count",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sog_water_thm.ncb/sog_water_thm.ncb.json
+++ b/src/db/bedrock-db-data/data/assets/sog_water_thm.ncb/sog_water_thm.ncb.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sog_water_thm.ncb",
+  "display_name": null,
   "description": "Water SOG Benchmark: water_thm",
   "location": {
     "tab": "water_thm",
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1m2xD4JyH4BEBey_ybsEgrvYopsl0PjWNmY_PEv3l6D4"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": [

--- a/src/db/bedrock-db-data/data/assets/sunlife_eligibility.mun/sunlife_eligibility.mun.json
+++ b/src/db/bedrock-db-data/data/assets/sunlife_eligibility.mun/sunlife_eligibility.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "sunlife_eligibility.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "sunlife_eligibility",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/telestaff_person.ftp/telestaff_person.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/telestaff_person.ftp/telestaff_person.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "telestaff_person.ftp",
+  "display_name": null,
   "description": "Upload Staff data to Telestaff FTP",
   "location": {
     "path": "/PROD/import/ongoing.unprocessed/",
     "filename": "${YYYY}-${MM}-${DD}T${HH}-${mm}-${SS}.000ZPerson.xml",
     "connection": "telestaff_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "telestaff_person.s3"

--- a/src/db/bedrock-db-data/data/assets/telestaff_person.s3/telestaff_person.s3.json
+++ b/src/db/bedrock-db-data/data/assets/telestaff_person.s3/telestaff_person.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "telestaff_person.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "telestaff-import-person/",
     "filename": "${YYYY}-${MM}-${DD}-Person.xml",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "telestaff_person01_xml.mun"

--- a/src/db/bedrock-db-data/data/assets/telestaff_person01_xml.mun/telestaff_person01_xml.mun.json
+++ b/src/db/bedrock-db-data/data/assets/telestaff_person01_xml.mun/telestaff_person01_xml.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "telestaff_person01_xml.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "telestaff_person01_xml",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/training_boards.lib/training_boards.lib.json
+++ b/src/db/bedrock-db-data/data/assets/training_boards.lib/training_boards.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "training_boards.lib",
+  "display_name": null,
   "description": "Training records for board and commission members",
   "location": {
     "tablename": "training_boards",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "boards+commission_member_training.goog"

--- a/src/db/bedrock-db-data/data/assets/training_students.lib/training_students.lib.json
+++ b/src/db/bedrock-db-data/data/assets/training_students.lib/training_students.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "training_students.lib",
+  "display_name": null,
   "description": "Student registrations for training classes",
   "location": {
     "tablename": "training_students",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "training_students.mun"

--- a/src/db/bedrock-db-data/data/assets/training_students.mun/training_students.mun.json
+++ b/src/db/bedrock-db-data/data/assets/training_students.mun/training_students.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "training_students.mun",
+  "display_name": null,
   "description": "Student registrations for training classes",
   "location": {
     "tablename": "training_students",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "amd"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/turnover_counts.lib/turnover_counts.lib.json
+++ b/src/db/bedrock-db-data/data/assets/turnover_counts.lib/turnover_counts.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "turnover_counts.lib",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "turnover_counts",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_sensitive_snapshots.lib"

--- a/src/db/bedrock-db-data/data/assets/turnover_employees.lib/turnover_employees.lib.json
+++ b/src/db/bedrock-db-data/data/assets/turnover_employees.lib/turnover_employees.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "turnover_employees.lib",
+  "display_name": null,
   "description": "Report of Employees who were termed this month",
   "location": {
     "tablename": "turnover_employees",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "standard"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "base_employee_sensitive_snapshots.lib"

--- a/src/db/bedrock-db-data/data/assets/ub_water_customers_everbridge.mun/ub_water_customers_everbridge.mun.json
+++ b/src/db/bedrock-db-data/data/assets/ub_water_customers_everbridge.mun/ub_water_customers_everbridge.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "ub_water_customers_everbridge.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "UB_Water_Customers_Everbridge",
     "connection": "munis/munprod/fme_jobs",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/vendors.lib/vendors.lib.json
+++ b/src/db/bedrock-db-data/data/assets/vendors.lib/vendors.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vendors.lib",
+  "display_name": null,
   "description": "City Vendors",
   "location": {
     "tablename": "vendors",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "ap_vendor.mun"

--- a/src/db/bedrock-db-data/data/assets/vxsmart_account/vxsmart_account.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_account/vxsmart_account.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_account.ftp",
+  "display_name": null,
   "description": "Uploaded Account data to vxsmart_account",
   "location": {
     "path": "/uploads/",
     "filename": "acctinfo_${YYYY}${MM}${DD}.csv",
     "connection": "vxsmart_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "vxsmart_account.s3"

--- a/src/db/bedrock-db-data/data/assets/vxsmart_account/vxsmart_account.mun.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_account/vxsmart_account.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_account.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "UB_AMI_VXSmart_Accounts_Nightly",
     "connection": "munistest19",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/vxsmart_account/vxsmart_account.s3.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_account/vxsmart_account.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_account.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "vxsmart/",
     "filename": "acctinfo_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "vxsmart_account.mun"

--- a/src/db/bedrock-db-data/data/assets/vxsmart_billing/vxsmart_billing.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_billing/vxsmart_billing.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_billing.ftp",
+  "display_name": null,
   "description": "Uploaded Billing data to vxsmart_billing",
   "location": {
     "path": "/uploads/",
     "filename": "billinginfo_${YYYY}${MM}${DD}.csv",
     "connection": "vxsmart_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "vxsmart_billing.s3"

--- a/src/db/bedrock-db-data/data/assets/vxsmart_billing/vxsmart_billing.mun.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_billing/vxsmart_billing.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_billing.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "UB_AMI_VXSmart_Billing_Nightly",
     "connection": "munistest19",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/vxsmart_billing/vxsmart_billing.s3.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_billing/vxsmart_billing.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_billing.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "vxsmart/",
     "filename": "billinginfo_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "vxsmart_billing.mun"

--- a/src/db/bedrock-db-data/data/assets/vxsmart_consumption/vxsmart_consumption.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_consumption/vxsmart_consumption.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_consumption.ftp",
+  "display_name": null,
   "description": "Uploaded Consumption data to vxsmart_consumption",
   "location": {
     "path": "/uploads/",
     "filename": "ch_${YYYY}${MM}${DD}.csv",
     "connection": "vxsmart_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "vxsmart_consumption.s3"

--- a/src/db/bedrock-db-data/data/assets/vxsmart_consumption/vxsmart_consumption.mun.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_consumption/vxsmart_consumption.mun.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_consumption.mun",
+  "display_name": null,
   "description": "",
   "location": {
     "tablename": "UB_AMI_VXSmart_Consumption_Nightly",
     "connection": "munistest19",
     "schemaname": "avl"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/vxsmart_consumption/vxsmart_consumption.s3.json
+++ b/src/db/bedrock-db-data/data/assets/vxsmart_consumption/vxsmart_consumption.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "vxsmart_consumption.s3",
+  "display_name": null,
   "description": "",
   "location": {
     "path": "vxsmart/",
     "filename": "ch_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "vxsmart_consumption.mun"

--- a/src/db/bedrock-db-data/data/assets/wex.ftp/wex.ftp.json
+++ b/src/db/bedrock-db-data/data/assets/wex.ftp/wex.ftp.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "wex.ftp",
+  "display_name": null,
   "description": "Wex fleet data",
   "location": {
     "path": "/data/",
     "filename": "AshevilleExport_PostedDate_${YYYY}${MM}${DD}.csv",
     "connection": "wex_ftp"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": false,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/wex.s3/wex.s3.json
+++ b/src/db/bedrock-db-data/data/assets/wex.s3/wex.s3.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "wex.s3",
+  "display_name": null,
   "description": "Wex File on s3",
   "location": {
     "path": "wex/",
     "filename": "AshevilleExport_PostedDate_${YYYY}${MM}${DD}.csv",
     "connection": "s3_data_files"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": false,
   "depends": [
     "wex.ftp"

--- a/src/db/bedrock-db-data/data/assets/wex.win/wex.win.json
+++ b/src/db/bedrock-db-data/data/assets/wex.win/wex.win.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "wex.win",
+  "display_name": null,
   "description": "Wex File on CityWorks Fleet file share",
   "location": {
     "path": "/wex/",
     "filename": "AshevilleExport_PostedDate_${YYYY}${MM}${DD}.csv",
     "connection": "cityworks_fleet"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": false,
   "depends": [
     "wex.ftp"

--- a/src/db/bedrock-db-data/data/assets/workplans.goog/workplans.goog.json
+++ b/src/db/bedrock-db-data/data/assets/workplans.goog/workplans.goog.json
@@ -1,5 +1,6 @@
 {
   "asset_name": "workplans.goog",
+  "display_name": null,
   "description": "Organizational Work Plan",
   "location": {
     "tab": "Sheet1",
@@ -8,8 +9,10 @@
     "connection": "bedrock-googlesheets",
     "spreadsheetid": "1lT8ep9PipcMiT5yVv-BkGaCRR331VN_4ANeWM0tQNgc"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [],
   "tags": []

--- a/src/db/bedrock-db-data/data/assets/workplans.lib/workplans.lib.json
+++ b/src/db/bedrock-db-data/data/assets/workplans.lib/workplans.lib.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "workplans.lib",
+  "display_name": null,
   "description": "Organizational Work Plan",
   "location": {
     "tablename": "workplans",
     "connection": "pubrecdb1/mdastore1/dbadmin",
     "schemaname": "internal"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "workplans.goog"

--- a/src/db/bedrock-db-data/data/assets/workplans.pub/workplans.pub.json
+++ b/src/db/bedrock-db-data/data/assets/workplans.pub/workplans.pub.json
@@ -1,13 +1,16 @@
 {
   "asset_name": "workplans.pub",
+  "display_name": null,
   "description": "Organizational Work Plan",
   "location": {
     "tablename": "workplans",
     "connection": "coa-publicdb1/coa_share/dbadmin",
     "schemaname": "open"
   },
+  "asset_type": null,
   "owner_id": null,
   "notes": null,
+  "link": null,
   "active": true,
   "depends": [
     "workplans.lib"

--- a/src/db/bedrock-db-data/data/custom_fields.csv
+++ b/src/db/bedrock-db-data/data/custom_fields.csv
@@ -1,0 +1,2 @@
+"metric","period","text"
+"metric","disaggregations","text[]"

--- a/src/db/bedrock-db-data/load_assets/load_assets.py
+++ b/src/db/bedrock-db-data/load_assets/load_assets.py
@@ -41,6 +41,8 @@ sql = f'''
   truncate table bedrock.tags;
   truncate table bedrock.run_groups;
   truncate table bedrock.connections;
+  truncate table bedrock.custom_fields;
+  truncate table bedrock.custom_values;
 '''
 cur.execute(sql)
 print('Truncated all tables')
@@ -183,6 +185,22 @@ for asset_subdir in os.listdir(assets_directory):
 
     # nm = cur.fetchone()[0] # probably can skip this, but maybe to double check
 
+# Load the custom fields
+sql = 'INSERT INTO bedrock.custom_fields (asset_type, field_name,	field_type) VALUES '
+customs = []
+with open(os.path.join(data_directory,'custom_fields.csv')) as ff:
+  rdr = csv.reader(ff)
+  
+  i = 0;
+  rows = list(rdr)
+  nrows = len(rows)
+  for row in rows:
+    i = i+1
+    sql = f"{sql} ('{row[0]}', '{row[1]}', '{row[2]}')"
+    if (i<nrows):
+      sql = sql + ','
+cur.execute(sql)
+print(f'Wrote {nrows} items to the custom fields table')
 
 conn.commit()
 cur.close()

--- a/src/db/bedrock-db-data/load_files/README.md
+++ b/src/db/bedrock-db-data/load_files/README.md
@@ -2,3 +2,5 @@
 
 This is a utility to create managed-data-assets json files from database tables.
 Not used in the running of the program, but useful for setting it up.
+
+You will need to run ```make install``` in the bedrock_common directory before running ```npm install; node loadfiles.js;``` here

--- a/src/db/bedrock-db-data/load_files/load_files.js
+++ b/src/db/bedrock-db-data/load_files/load_files.js
@@ -149,10 +149,12 @@ async function writeOther(client, data_directory, tablename) {
     fs.mkdirSync(assets_directory);
   }
 
+  console.log('Connect to the DB');
   const dbConnection = await getDBConnection();
   const client = new Client(dbConnection);
   await client.connect();
-
+  console.log('Connected, create the files');
+  
   // load etl files
   let etlList = await readEtlList(client);
   etlList = await readTasks(client, etlList);

--- a/src/db/bedrock-db-data/load_files/package-lock.json
+++ b/src/db/bedrock-db-data/load_files/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bedrock_common": "file:../../../bedrock_common",
+        "bedrock_common": "file:../../../bedrock_common/bedrock_common",
         "pg": "^8.10.0",
         "toposort": "^2.0.2"
       },
@@ -22,6 +22,13 @@
     "../../../bedrock_common": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "../../../bedrock_common/bedrock_common": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@aws-sdk/client-secrets-manager": "^3.450.0"
+      }
     },
     "../../../src/bedrock_common": {
       "extraneous": true
@@ -318,7 +325,7 @@
       "dev": true
     },
     "node_modules/bedrock_common": {
-      "resolved": "../../../bedrock_common",
+      "resolved": "../../../bedrock_common/bedrock_common",
       "link": true
     },
     "node_modules/brace-expansion": {
@@ -2506,7 +2513,10 @@
       "dev": true
     },
     "bedrock_common": {
-      "version": "file:../../../bedrock_common"
+      "version": "file:../../../bedrock_common/bedrock_common",
+      "requires": {
+        "@aws-sdk/client-secrets-manager": "^3.450.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/src/db/bedrock-db/createNewBedrockDB.sql
+++ b/src/db/bedrock-db/createNewBedrockDB.sql
@@ -132,3 +132,17 @@ CREATE TABLE bedrock.tasks (
 -- Permissions
 ALTER TABLE bedrock.tasks OWNER TO bedrock_user;
 GRANT ALL ON TABLE bedrock.tasks TO bedrock_user;
+
+-- DROP TABLE bedrock.custom_types
+CREATE TABLE bedrock.custom_fields (
+  asset_type text NOT NULL,
+  field_name text NOT NULL,
+  field_type text NOT NULL
+);
+
+-- DROP TABLE bedrock.custom_values
+CREATE TABLE bedrock.custom_values (
+  asset_name text NOT NULL,
+  field_name text NOT NULL,
+  field_value text NULL
+);

--- a/src/db/bedrock-db/createNewBedrockDB.sql
+++ b/src/db/bedrock-db/createNewBedrockDB.sql
@@ -51,10 +51,13 @@ GRANT ALL ON TABLE bedrock.connections TO bedrock_user;
 -- DROP TABLE bedrock.assets;
 CREATE TABLE bedrock.assets (
 	asset_name text NOT NULL,
+  display_name text NULL,
 	description text NULL,
 	"location" jsonb NULL,
+  asset_type text NULL,
   owner_id integer NULL,
   notes text NULL,
+  link text NULL,
 	active bool NOT NULL,
 	CONSTRAINT assets_pkey PRIMARY KEY (asset_name)
 );

--- a/src/db/bedrock-db/createNewBedrockDB.sql
+++ b/src/db/bedrock-db/createNewBedrockDB.sql
@@ -140,9 +140,17 @@ CREATE TABLE bedrock.custom_fields (
   field_type text NOT NULL
 );
 
+-- Permissions
+ALTER TABLE bedrock.custom_fields OWNER TO bedrock_user;
+GRANT ALL ON TABLE bedrock.custom_fields TO bedrock_user;
+                                      
 -- DROP TABLE bedrock.custom_values
 CREATE TABLE bedrock.custom_values (
   asset_name text NOT NULL,
   field_name text NOT NULL,
   field_value text NULL
 );
+
+-- Permissions
+ALTER TABLE bedrock.custom_values OWNER TO bedrock_user;
+GRANT ALL ON TABLE bedrock.custom_values TO bedrock_user;

--- a/src/db/bedrock-db/createNewBedrockDB.sql
+++ b/src/db/bedrock-db/createNewBedrockDB.sql
@@ -133,7 +133,7 @@ CREATE TABLE bedrock.tasks (
 ALTER TABLE bedrock.tasks OWNER TO bedrock_user;
 GRANT ALL ON TABLE bedrock.tasks TO bedrock_user;
 
--- DROP TABLE bedrock.custom_types
+-- DROP TABLE bedrock.custom_fields
 CREATE TABLE bedrock.custom_fields (
   asset_type text NOT NULL,
   field_name text NOT NULL,


### PR DESCRIPTION
Added 3 new fields to the standard metadata: ```display_name```, ```asset_type```, and ```link```. This required updating all the asset files.

Also added the ability to define custom fields associated with a specific asset_type. This required two new tables: ```custom_fields``` and ```custom_values```.

