### PR TITLE
Use Map instead of plain object to build asset results. Fix missing client.end()s. Add fields query parameter to getAssetList

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
@@ -103,7 +103,7 @@ async function getAllAssetRelations(pathElements, queryParams, connection) {
   let client;
   let relations;
   let res;
-  const result = {
+  const response = {
     error: false,
     message: '',
     result: {
@@ -121,34 +121,34 @@ async function getAllAssetRelations(pathElements, queryParams, connection) {
   try {
     client = await newClient(connection);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   try {
     res = await readAsset(client, assetName);
     if (res.rowCount === 0) {
-      result.message = 'No assets found';
-      return result;
+      response.message = 'No assets found';
+      return response;
     }
     relations = await readRelations(client, assetName);
   } catch (error) {
     await client.end();
-    result.error = true;
-    result.message = error.message;
+    response.error = true;
+    response.message = error.message;
     await client.end();
-    return result;
+    return response;
   }
 
   await client.end();
 
-  result.result.ancestors.items = relations.ancestors.items;
-  result.result.ancestors.unique_items = relations.ancestors.unique_items;
-  result.result.descendants.items = relations.descendants.items;
-  result.result.descendants.unique_items = relations.descendants.unique_items;
+  response.result.ancestors.items = relations.ancestors.items;
+  response.result.ancestors.unique_items = relations.ancestors.unique_items;
+  response.result.descendants.items = relations.descendants.items;
+  response.result.descendants.unique_items = relations.descendants.unique_items;
 
-  return result;
+  return response;
 }
 
 module.exports = getAllAssetRelations;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -80,6 +80,7 @@ async function addBaseFields(asset, assetRows, requestedFields, available) {
   }
   return;
 }
+
 async function addTags(client, asset, pathElements) {
   const tags = [];
   const res = await client
@@ -117,16 +118,16 @@ async function getAsset(pathElements, queryParams, connection) {
     'etl_run_group',
     'etl_active',
   ];
-  const result = {
+  const response = {
     error: false,
     message: '',
     result: null,
   };
   const asset = new Map();
-  let requestedFields = null;
   let client;
 
   // Use fields from the query if they're present, otherwise use all available
+  let requestedFields = null;
   if ('fields' in queryParams) {
     requestedFields = queryParams.fields.replace('[', '').replace(']', '').split(',');
   } else {
@@ -136,9 +137,9 @@ async function getAsset(pathElements, queryParams, connection) {
   try {
     client = await newClient(connection);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   try {
@@ -152,15 +153,15 @@ async function getAsset(pathElements, queryParams, connection) {
     }
   } catch (error) {
     await client.end();
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   await client.end()
   // Convert the map back to an object
-  result.result = Object.fromEntries(asset.entries());
-  return result;
+  response.result = Object.fromEntries(asset.entries());
+  return response;
  }
 
 module.exports = getAsset;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
@@ -98,34 +98,6 @@ async function addBaseFields(assets, sqlResult, requestedFields, availableFields
   return assets;
 }
 
-function buildURL(queryParams, domainName, rowsReadCount, offset, total, pathElements) {
-  let qPrefix = '?';
-  let qParams = '';
-  if ('pattern' in queryParams) {
-    qParams += `${qPrefix}pattern=${queryParams.pattern}`;
-    qPrefix = '&';
-  }
-  if ('rungroups' in queryParams) {
-    qParams += `${qPrefix}rungroups=${queryParams.rungroups}`;
-    qPrefix = '&';
-  }
-  if ('period' in queryParams) {
-    qParams += `${qPrefix}period=${queryParams.period}`;
-    qPrefix = '&';
-  }
-  if ('count' in queryParams) {
-    qParams += `${qPrefix}count=${queryParams.count}`;
-    qPrefix = '&';
-  }
-  let url = null;
-  if (offset + rowsReadCount < total) {
-    const newOffset = parseInt(offset, 10) + rowsReadCount;
-    url = `https://${domainName}/${pathElements.join('/')}${qParams}`;
-    url += `${qPrefix}offset=${newOffset.toString()}`;
-  }
-  return url;
-}
-
 async function addCustomFields(client, assets, requestedFields, overrideFields) {
   const sql = `
     select asset_name, field_name, field_value from bedrock.custom_values
@@ -165,6 +137,34 @@ async function addDependencies(client, assets) {
     assets.assetMap.get(row.asset_name).get('parents').push(row.dependency);
   }
   return;
+}
+
+function buildURL(queryParams, domainName, rowsReadCount, offset, total, pathElements) {
+  let qPrefix = '?';
+  let qParams = '';
+  if ('pattern' in queryParams) {
+    qParams += `${qPrefix}pattern=${queryParams.pattern}`;
+    qPrefix = '&';
+  }
+  if ('rungroups' in queryParams) {
+    qParams += `${qPrefix}rungroups=${queryParams.rungroups}`;
+    qPrefix = '&';
+  }
+  if ('period' in queryParams) {
+    qParams += `${qPrefix}period=${queryParams.period}`;
+    qPrefix = '&';
+  }
+  if ('count' in queryParams) {
+    qParams += `${qPrefix}count=${queryParams.count}`;
+    qPrefix = '&';
+  }
+  let url = null;
+  if (offset + rowsReadCount < total) {
+    const newOffset = parseInt(offset, 10) + rowsReadCount;
+    url = `https://${domainName}/${pathElements.join('/')}${qParams}`;
+    url += `${qPrefix}offset=${newOffset.toString()}`;
+  }
+  return url;
 }
 
 async function getAssetList(domainName, pathElements, queryParams, connection) {

--- a/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
@@ -24,7 +24,7 @@ async function readTasks(client, assetName) {
 }
 
 async function getTasks(pathElements, queryParams, connection) {
-  const result = {
+  const response = {
     error: false,
     message: '',
     result: null,
@@ -36,9 +36,9 @@ async function getTasks(pathElements, queryParams, connection) {
   try {
     client = await newClient(connection);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   let res;
@@ -46,14 +46,14 @@ async function getTasks(pathElements, queryParams, connection) {
     res = await readTasks(client, assetName);
   } catch (error) {
     await client.end();
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   if (res.rowCount === 0) {
-    result.message = 'No tasks found';
-    return result;
+    response.message = 'No tasks found';
+    return response;
   }
 
   for (let i = 0; i < res.rowCount; i += 1) {
@@ -73,11 +73,11 @@ async function getTasks(pathElements, queryParams, connection) {
 
   await client.end();
 
-  result.result = {
+  response.result = {
     items: tasks,
   };
 
-  return result;
+  return response;
 }
 
 module.exports = getTasks;

--- a/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
@@ -9,7 +9,7 @@ const getTasks = require('./getTasks');
 
 // eslint-disable-next-line no-unused-vars
 async function handleAssets(event, pathElements, queryParams, verb, connection) {
-  let result = {
+  let response = {
     error: false,
     message: '',
     result: null,
@@ -18,7 +18,7 @@ async function handleAssets(event, pathElements, queryParams, verb, connection) 
   switch (pathElements.length) {
     // GET assets
     case 1:
-      result = await getAssetList(
+      response = await getAssetList(
         event.requestContext.domainName,
         pathElements,
         queryParams,
@@ -30,24 +30,24 @@ async function handleAssets(event, pathElements, queryParams, verb, connection) 
     case 2:
       switch (verb) {
         case 'GET':
-          result = await getAsset(pathElements, queryParams, connection);
+          response = await getAsset(pathElements, queryParams, connection);
           break;
 
         case 'POST':
-          result = await addAsset(event.body, pathElements, queryParams, connection);
+          response = await addAsset(event.body, pathElements, queryParams, connection);
           break;
 
         case 'PUT':
-          result = await updateAsset(event.body, pathElements, queryParams, connection);
+          response = await updateAsset(event.body, pathElements, queryParams, connection);
           break;
 
         case 'DELETE':
-          result = deleteAsset(pathElements, queryParams, connection);
+          response = deleteAsset(pathElements, queryParams, connection);
           break;
 
         default:
-          result.message = `handleAssets: unknown verb ${verb}`;
-          result.error = true;
+          response.message = `handleAssets: unknown verb ${verb}`;
+          response.error = true;
           break;
       }
       break;
@@ -57,16 +57,16 @@ async function handleAssets(event, pathElements, queryParams, verb, connection) 
     case 3:
       if (pathElements[2] === 'tasks') {
         if (verb === 'GET') {
-          result = await getTasks(pathElements, queryParams, connection);
+          response = await getTasks(pathElements, queryParams, connection);
         } else if (verb === 'DELETE') {
-          result.message = 'Delete all asset tasks not implemented';
-          result.error = true;
+          response.message = 'Delete all asset tasks not implemented';
+          response.error = true;
         }
       } else if (pathElements[2] === 'relations') {
-        result = await getAllAssetRelations(pathElements, queryParams, connection);
+        response = await getAllAssetRelations(pathElements, queryParams, connection);
       } else {
-        result.message = `Unknown assets endpoint: [${pathElements.join()}]`;
-        result.error = true;
+        response.message = `Unknown assets endpoint: [${pathElements.join()}]`;
+        response.error = true;
       }
       break;
 
@@ -74,45 +74,45 @@ async function handleAssets(event, pathElements, queryParams, verb, connection) 
     // GET /bedrock/assets/search/{searchString}
     case 4:
       if (pathElements[1] === 'search') {
-        result.message = 'Assets search not implemented';
-        result.error = true;
+        response.message = 'Assets search not implemented';
+        response.error = true;
       } else if (pathElements[2] === 'tasks') {
         switch (verb) {
           case 'POST':
-            result.message = 'Add asset task not implemented';
-            result.error = true;
+            response.message = 'Add asset task not implemented';
+            response.error = true;
             break;
 
           case 'PUT':
-            result.message = 'Update asset task not implemented';
-            result.error = true;
+            response.message = 'Update asset task not implemented';
+            response.error = true;
             break;
 
           case 'DELETE':
-            result.message = 'Delete asset task not implemented';
-            result.error = true;
+            response.message = 'Delete asset task not implemented';
+            response.error = true;
             break;
 
           default:
-            result.message = `handleAssets: unknown verb ${verb}`;
-            result.error = true;
+            response.message = `handleAssets: unknown verb ${verb}`;
+            response.error = true;
             break;
         }
       } else {
-        result.message = `Unknown assets endpoint: [${pathElements.join()}]`;
-        result.error = true;
+        response.message = `Unknown assets endpoint: [${pathElements.join()}]`;
+        response.error = true;
       }
       break;
 
     default:
-      result.message = `Unknown assets endpoint: [${pathElements.join()}]`;
-      result.error = true;
+      response.message = `Unknown assets endpoint: [${pathElements.join()}]`;
+      response.error = true;
       break;
   }
-  if (result.error) {
-    console.log(`We have an error but do not know why! - ${result.message}`);
+  if (response.error) {
+    console.log(`We have an error but do not know why! - ${response.message}`);
   }
-  return result;
+  return response;
 }
 
 module.exports = handleAssets;


### PR DESCRIPTION
Switching to using a Map instead of a plain object allows significant cleanup, especially in the get functions. Also found a couple places where we needed to call client.end.

In the course of the cleanup, went ahead and implmented the fields query parameter for getAssetList as well.
