### PR TITLE
Reformatting/restructuring asset files

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -78,7 +78,8 @@ async function baseDelete(client, assetName) {
 async function deleteAsset(pathElements, queryParams, connection) {
   const assetName = pathElements[1];
   let client;
-  const result = {
+  // no need for building a map object to send to the requester, as we only return the asset name. 
+  const response= {
     error: false,
     message: `Successfully deleted asset ${assetName}`,
     result: null,
@@ -87,18 +88,18 @@ async function deleteAsset(pathElements, queryParams, connection) {
   try {
     client = await newClient(connection);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   try {
     await checkExistence(client, assetName);
   } catch (error) {
     await client.end();
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   await client.query('BEGIN');
@@ -111,15 +112,15 @@ async function deleteAsset(pathElements, queryParams, connection) {
     await customFieldsDelete(client, assetName);
     await baseDelete(client, assetName);
     await client.query('COMMIT');
-    await client.end();
   } catch (error) {
     await client.query('ROLLBACK');
+    response.error = true;
+    response.message = error.message;
+  } finally {
     await client.end();
-    result.error = true;
-    result.message = error.message;
+    return response;
   }
 
-  return result;
 }
 
 module.exports = deleteAsset;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
@@ -133,22 +133,18 @@ async function getAllAssetRelations(pathElements, queryParams, connection) {
       return response;
     }
     relations = await readRelations(client, assetName);
+    response.result.ancestors.items = relations.ancestors.items;
+    response.result.ancestors.unique_items = relations.ancestors.unique_items;
+    response.result.descendants.items = relations.descendants.items;
+    response.result.descendants.unique_items = relations.descendants.unique_items;
   } catch (error) {
-    await client.end();
     response.error = true;
     response.message = error.message;
-    await client.end();
     return response;
+  } finally {
+    await client.end();
+    return response
   }
-
-  await client.end();
-
-  response.result.ancestors.items = relations.ancestors.items;
-  response.result.ancestors.unique_items = relations.ancestors.unique_items;
-  response.result.descendants.items = relations.descendants.items;
-  response.result.descendants.unique_items = relations.descendants.unique_items;
-
-  return response;
 }
 
 module.exports = getAllAssetRelations;


### PR DESCRIPTION
I'm going through all the files are trying to standardize their format/structure a bit better.

In some of the files (getTask and getAssetRelations atleast I believe) it didn't feel like it made sense to create a map object. The data being returned was in a simpler structure, so it was easier to just assign the data to response.result without having the extra "create a map" step.