### PR TITLE
Cleanup and formatting of rungroup files

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/rungroups/addRungroup.js
+++ b/src/api/lambdas/bedrock-api-backend/rungroups/addRungroup.js
@@ -63,7 +63,7 @@ async function addRungroup(requestBody, pathElements, queryParams, connection) {
   const body = JSON.parse(requestBody);
   let client;
 
-  const result = {
+  const response = {
     error: false,
     message: '',
     result: null,
@@ -73,21 +73,21 @@ async function addRungroup(requestBody, pathElements, queryParams, connection) {
     client = await newClient(connection);
     checkInfo(body, pathElements);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   try {
     await checkExistence(client, pathElements);
-    result.result = await baseInsert(client, body);
+    response.result = await baseInsert(client, body);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
+    response.error = true;
+    response.message = error.message;
   } finally {
     await client.end();
+    return response;
   }
-  return result;
 }
 
 module.exports = addRungroup;

--- a/src/api/lambdas/bedrock-api-backend/rungroups/deleteRungroup.js
+++ b/src/api/lambdas/bedrock-api-backend/rungroups/deleteRungroup.js
@@ -44,7 +44,7 @@ async function baseDelete(client, rungroupName) {
 async function deleteRungroup(pathElements, queryParams, connection) {
   const rungroupName = pathElements[1];
   let client;
-  const result = {
+  const response = {
     error: false,
     message: `Successfully deleted asset ${rungroupName}`,
     result: null,
@@ -53,30 +53,30 @@ async function deleteRungroup(pathElements, queryParams, connection) {
   try {
     client = await newClient(connection);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   try {
     await checkExistence(client, rungroupName);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
+    response.error = true;
+    response.message = error.message;
     await client.end();
-    return result;
+    return response;
   }
 
   try {
     await baseDelete(client, rungroupName);
-    await client.end();
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
+    response.error = true;
+    response.message = error.message;
+  } finally {
     await client.end();
+    return response;
   }
 
-  return result;
 }
 
 module.exports = deleteRungroup;

--- a/src/api/lambdas/bedrock-api-backend/rungroups/getRungroup.js
+++ b/src/api/lambdas/bedrock-api-backend/rungroups/getRungroup.js
@@ -28,7 +28,7 @@ async function getInfo(client, pathElements) {
 }
 
 async function getRungroup(pathElements, queryParams, connection) {
-  const result = {
+  const response = {
     error: false,
     message: '',
     result: null,
@@ -38,20 +38,21 @@ async function getRungroup(pathElements, queryParams, connection) {
   try {
     client = await newClient(connection);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
-    return result;
+    response.error = true;
+    response.message = error.message;
+    return response;
   }
 
   try {
-    result.result = await getInfo(client, pathElements);
-    await client.end();
+    response.result = await getInfo(client, pathElements);
   } catch (error) {
-    result.error = true;
-    result.message = error.message;
+    response.error = true;
+    response.message = error.message;
+  } finally {
+    await client.end();
+    return response;
   }
 
-  return result;
 }
 
 module.exports = getRungroup;

--- a/src/api/lambdas/bedrock-api-backend/rungroups/updateRungroup.js
+++ b/src/api/lambdas/bedrock-api-backend/rungroups/updateRungroup.js
@@ -88,22 +88,15 @@ async function updateRungroup(requestBody, pathElements, queryParams, connection
 
   try {
     await checkExistence(client, rungroupName);
+    rungroup = await baseInsert(client, body, rungroupName);
+    response.result = Object.fromEntries(rungroup.entries());
   } catch (error) {
     response.error = true;
     response.message = error.message;
+  } finally {
     await client.end();
     return response;
   }
-  try {
-    rungroup = await baseInsert(client, body, rungroupName);
-    await client.end();
-  } catch (error) {
-    await client.end();
-    response.error = true;
-    response.message = error.message;
-  }
-  response.result = Object.fromEntries(rungroup.entries());
-  return response;
 }
 
 module.exports = updateRungroup;


### PR DESCRIPTION
Pretty minor changes; most of the rungroup files don't need to build objects that are too complicated so I didn't even need to use maps in many of the files.

The one exception is getRungroupList, which I went around in circles a bit with. I ended up using a map, but kept some redundant variables because they made it easier to read. Not sure if that was the best decision or not.