### PR TITLE
Fixing lint errors

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -13,7 +13,7 @@ function checkCustomFields(body) {
   }
 }
 
-async function addCustomFieldsInfo(client, idValue, body, tableName, name) {
+async function addCustomFieldsInfo(client, idValue, body) {
   let res;
   const valueStrings = [];
   console.log(body.custom_fields);
@@ -25,8 +25,7 @@ async function addCustomFieldsInfo(client, idValue, body, tableName, name) {
   });
   const combinedValueString = valueStrings.join(', ');
   console.log(valueStrings);
-  console.log(`INSERT INTO bedrock.asset_type_custom_fields (asset_type_id, custom_field_id, required) VALUES ${combinedValueString}`,
-);
+  console.log(`INSERT INTO bedrock.asset_type_custom_fields (asset_type_id, custom_field_id, required) VALUES ${combinedValueString}`);
 
   try {
     res = await client
@@ -82,7 +81,7 @@ async function addAssetType(
   try {
     await client.query('BEGIN');
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    await addCustomFieldsInfo(client, idValue, body, tableName, name);
+    await addCustomFieldsInfo(client, idValue, body);
     response.result = await addInfo(client, allFields, body, tableName, name);
     await client.query('COMMIT');
     await client.end();

--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, addInfo,

--- a/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkExistence, deleteInfo,

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getAssetType.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient, getInfo, capitalizeFirstLetter } from '../utilities/utilities.js';
 import pgErrorCodes from '../pgErrorCodes.js';

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getAssetTypeList.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getAssetTypeList.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient, capitalizeFirstLetter } from '../utilities/utilities.js';
 import {

--- a/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getAssetTypeList from './getAssetTypeList.js';
 import getAssetType from './getAssetType.js';

--- a/src/api/lambdas/bedrock-api-backend/asset_types/updateAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/updateAssetType.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, updateInfo, deleteInfo,

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -2,9 +2,10 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
 import getCustomFieldsInfo from '../common/getCustomFieldInfo.js';
+
+const { Client } = pgpkg;
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -92,7 +93,7 @@ async function baseInsert(body, customFields, customValues, client) {
   ];
   sql = 'INSERT INTO assets (asset_name, description, location, active';
   let vals = ') VALUES($1, $2, $3, $4';
-  let fields = ['owner_id', 'notes', 'link', 'display_name', 'asset_type']
+  const fields = ['owner_id', 'notes', 'link', 'display_name', 'asset_type']
 
   for (let i = 0; i < fields.length; i += 1) {
     if (fields[i] in body) {
@@ -125,7 +126,8 @@ async function baseInsert(body, customFields, customValues, client) {
       if (fields[0] in body) {
         tempAsset.set(fields[0], body[fields[0]])
       }
-  }}
+    }
+  }
 
   // Now deal with custom fields
   const customOut = new Map();

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-console */
 import pgpkg from 'pg';

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -1,5 +1,7 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
+
 const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
 

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -1,9 +1,9 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
+import pgErrorCodes from '../pgErrorCodes.js';
 
 const { Client } = pgpkg;
-import pgErrorCodes from '../pgErrorCodes.js';
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -62,7 +62,7 @@ async function tagsDelete(client, assetName) {
   }
 }
 
-async function customFieldsDelete (client, assetName) {
+async function customFieldsDelete(client, assetName) {
   try {
     await client.query('delete from bedrock.custom_values where asset_name = $1', [assetName]);
   } catch (error) {
@@ -121,9 +121,8 @@ async function deleteAsset(pathElements, queryParams, connection) {
     response.message = error.message;
   } finally {
     await client.end();
-    return response;
   }
-
+  return response;
 }
 
 export default deleteAsset;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 const { Client } = pgpkg;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
@@ -1,8 +1,9 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
+
+const { Client } = pgpkg;
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -145,8 +146,8 @@ async function getAllAssetRelations(pathElements, queryParams, connection) {
     return response;
   } finally {
     await client.end();
-    return response
   }
+  return response;
 }
 
 export default getAllAssetRelations;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 const { Client } = pgpkg;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -1,8 +1,9 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
+
+const { Client } = pgpkg;
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -53,21 +54,20 @@ async function addCustomFields(client, asset, requestedFields, fieldsOverride) {
         }
       }
     }
-
   }
   return Object.fromEntries(cv.entries());
 }
 
 async function addBaseFields(assetRows, requestedFields, available) {
-  let tempAsset = new Map()
+  const tempAsset = new Map();
   tempAsset.set('asset_name', assetRows[0].asset_name);
   tempAsset.set('asset_type', assetRows[0].asset_type);
-  
+
   for (let j = 0; j < requestedFields.length; j += 1) {
     const itm = requestedFields[j];
     if (available.includes(itm)) {
       if (itm === 'parents') {
-        let parents = [];
+        const parents = [];
         for (let i = 0; i < assetRows.length; i += 1) {
           if (assetRows[i].dependency !== null) {
             parents.push(assetRows[i].dependency);
@@ -160,9 +160,9 @@ async function getAsset(pathElements, queryParams, connection) {
     response.error = true;
     response.message = error.message;
   } finally {
-    await client.end()
-    return response;
+    await client.end();
   }
- }
+  return response;
+}
 
 export default getAsset;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 import pgpkg from 'pg';
 const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';

--- a/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAssetList.js
@@ -1,7 +1,8 @@
 /* eslint-disable import/extensions */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
+
+const { Client } = pgpkg;
 
 function checkParameters(queryParams) {
   const parameters = ['rungroup', 'tags', 'period', 'pattern', 'count', 'offset'];
@@ -37,7 +38,7 @@ function createSqlWhereClause(queryParams) {
     sqlParams: [],
   };
   if ('pattern' in queryParams) {
-    whereClause.whereClause = `where a.asset_name like $1`;
+    whereClause.whereClause = 'where a.asset_name like $1';
     whereClause.sqlParams.push(`%${queryParams.pattern}%`);
   }
   return whereClause;
@@ -55,7 +56,7 @@ async function getAssetCount(whereClause, client) {
 }
 
 async function readAssets(client, offset, count, whereClause) {
-  let sql = `
+  const sql = `
     SELECT a.*, e.run_group as etl_run_group, e.active as etl_active,
       c.connection_class FROM bedrock.assets a
     left join bedrock.etl e on a.asset_name = e.asset_name

--- a/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 const { Client } = pgpkg;

--- a/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
@@ -1,8 +1,9 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
+
+const { Client } = pgpkg;
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -26,7 +27,7 @@ async function readTasks(client, assetName) {
 }
 
 function formatTasks(res) {
-  let tempTasks = [];
+  const tempTasks = [];
   for (let i = 0; i < res.rowCount; i += 1) {
     tempTasks.push(
       {
@@ -68,7 +69,7 @@ async function getTasks(pathElements, queryParams, connection) {
     if (res.rowCount === 0) {
       response.message = 'No tasks found';
     } else {
-      tasks = formatTasks(res)
+      tasks = formatTasks(res);
       response.result = {
         items: tasks,
       };
@@ -79,9 +80,9 @@ async function getTasks(pathElements, queryParams, connection) {
     response.message = error.message;
     return response;
   } finally {
-    await client.end()
-    return response;
+    await client.end();
   }
+  return response;
 }
 
 export default getTasks;

--- a/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getAssetList from './getAssetList.js';
 import getAsset from './getAsset.js';

--- a/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
@@ -2,9 +2,10 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
 import getCustomFieldsInfo from '../common/getCustomFieldInfo.js';
+
+const { Client } = pgpkg;
 
 async function newClient(connection) {
   const client = new Client(connection);

--- a/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-console */
 import pgpkg from 'pg';

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/addCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/addCustomField.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, addInfo,

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkExistence, deleteInfo,

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomField.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient, getInfo } from '../utilities/utilities.js';
 

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomFieldList.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomFieldList.js
@@ -5,7 +5,6 @@ import {
   buildCount, buildOffset, buildWhereClause, getCount, getListInfo, buildURL,
 } from '../utilities/listUtilities.js';
 
-
 async function getCustomFieldList(
   domainName,
   pathElements,

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomFieldList.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomFieldList.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient } from '../utilities/utilities.js';
 import {

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getCustomFieldList from './getCustomFieldList.js';
 import getCustomField from './getCustomField.js';

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/updateCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/updateCustomField.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, updateInfo,

--- a/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { customAlphabet } from 'nanoid';

--- a/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { customAlphabet } from 'nanoid';
 import {

--- a/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkExistence, deleteInfo,

--- a/src/api/lambdas/bedrock-api-backend/owners/getOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/getOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient, getInfo } from '../utilities/utilities.js';
 

--- a/src/api/lambdas/bedrock-api-backend/owners/getOwnerList.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/getOwnerList.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient } from '../utilities/utilities.js';
 import {

--- a/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getOwnerList from './getOwnerList.js';
 import getOwner from './getOwner.js';

--- a/src/api/lambdas/bedrock-api-backend/owners/updateOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/updateOwner.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, updateInfo,

--- a/src/api/lambdas/bedrock-api-backend/reference/getReference.js
+++ b/src/api/lambdas/bedrock-api-backend/reference/getReference.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 const { Client } = pgpkg;

--- a/src/api/lambdas/bedrock-api-backend/reference/getReference.js
+++ b/src/api/lambdas/bedrock-api-backend/reference/getReference.js
@@ -1,9 +1,10 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
 import getCustomFieldsInfo from '../common/getCustomFieldInfo.js';
+
+const { Client } = pgpkg;
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -18,23 +19,22 @@ async function newClient(connection) {
 async function getInfo(client, info) {
   let sql = `SELECT * FROM bedrock.${info.table_name}`;
   let res;
-  let resultArray = []
+  let resultArray = [];
 
-  if (info.field_name != 'all') {
+  if (info.field_name !== 'all') {
     sql += ` order by ${info.field_name} asc`;
   }
 
-
   try {
     res = await client.query(sql, []);
-    // Either build the array of strings if you just need one field, 
+    // Either build the array of strings if you just need one field,
     // or just add the entire res.rows if you need all fields
-    if (info.field_name != 'all') {
-      for (let i=0;i<res.rows.length;i++) {
-        resultArray.push(res.rows[i][info.field_name])
+    if (info.field_name !== 'all') {
+      for (let i = 0; i < res.rows.length; i += 1) {
+        resultArray.push(res.rows[i][info.field_name]);
       }
     } else {
-      resultArray = res.rows
+      resultArray = res.rows;
     }
   } catch (error) {
     throw new Error(`PG error getting ${info.table_name} information: ${pgErrorCodes[error.code]}`);
@@ -44,15 +44,15 @@ async function getInfo(client, info) {
 }
 
 async function getTaskType(client) {
-  let sql = `SELECT unnest(enum_range(NULL::task_types)) as task_type;`;
+  const sql = 'SELECT unnest(enum_range(NULL::task_types)) as task_type;';
   let res;
-  let resultArray = []
+  const resultArray = [];
 
   // We're only adding unique task types
   try {
     res = await client.query(sql, []);
-    for (let i=0;i<res.rows.length;i++) {
-      resultArray.push(res.rows[i]['task_type'])
+    for (let i = 0; i < res.rows.length; i += 1) {
+      resultArray.push(res.rows[i].task_type);
     }
   } catch (error) {
     throw new Error(`PG error getting tasks information: ${pgErrorCodes[error.code]}`);
@@ -62,15 +62,15 @@ async function getTaskType(client) {
 }
 
 async function getConnectionClass(client) {
-  let sql = `SELECT unnest(enum_range(NULL::connections_classes)) as connection_class;`;
+  const sql = 'SELECT unnest(enum_range(NULL::connections_classes)) as connection_class;';
   let res;
-  let resultArray = []
+  const resultArray = [];
 
   // We're only adding unique task types
   try {
     res = await client.query(sql, []);
-    for (let i=0;i<res.rows.length;i++) {
-      resultArray.push(res.rows[i]['connection_class'])
+    for (let i = 0; i < res.rows.length; i += 1) {
+      resultArray.push(res.rows[i].connection_class);
     }
   } catch (error) {
     throw new Error(`PG error getting tasks information: ${pgErrorCodes[error.code]}`);
@@ -80,7 +80,7 @@ async function getConnectionClass(client) {
 }
 
 async function getCustomFields(client) {
-  let sql = `SELECT id, name FROM bedrock.asset_types`;
+  const sql = 'SELECT id, name FROM bedrock.asset_types';
   let res;
 
   const resultMap = new Map();
@@ -88,7 +88,7 @@ async function getCustomFields(client) {
 
   try {
     res = await client.query(sql, []);
-    res.rows.forEach(row => {
+    res.rows.forEach((row) => {
       types.push(row.id);
       const typeMap = new Map();
       typeMap.set('name', row.name);
@@ -97,13 +97,14 @@ async function getCustomFields(client) {
   } catch (error) {
     throw new Error(`PG error getting asset types: ${pgErrorCodes[error.code]}`);
   }
+  let type;
   for (type of types) {
-    let customFields = await getCustomFieldsInfo(client, type);
+    const customFields = await getCustomFieldsInfo(client, type);
     const typeMap = resultMap.get(type);
     typeMap.set('fields', Object.fromEntries(customFields.entries()));
   }
- 
-  for (let [id, itm] of resultMap) {
+
+  for (const [id, itm] of resultMap) {
     resultMap[id] = Object.fromEntries(resultMap.get(id).entries());
   }
 
@@ -114,21 +115,21 @@ async function getReference(domainName, pathElements, queryParams, connection) {
   const result = {
     error: false,
     message: '',
-    result: {}
+    result: {},
   };
 
   let client;
 
   // if you want to add info from a new another table, and need either a single column
   // or all the columns, just add it to this array
-  queryInfo = [
-  {table_name: 'run_groups', field_name: 'run_group_name'},
-  {table_name: 'tags', field_name: 'all'},
-  {table_name: 'connections', field_name: 'all'},
-  {table_name: 'owners', field_name: 'all'},
-]
+  const queryInfo = [
+    { table_name: 'run_groups', field_name: 'run_group_name' },
+    { table_name: 'tags', field_name: 'all' },
+    { table_name: 'connections', field_name: 'all' },
+    { table_name: 'owners', field_name: 'all' },
+  ];
 
-// get a new client
+  // get a new client
   try {
     client = await newClient(connection);
   } catch (error) {
@@ -138,7 +139,7 @@ async function getReference(domainName, pathElements, queryParams, connection) {
   }
 
   // loop through queryInfo array, adding info for each table listed in the array
-  for (let i=0;i<queryInfo.length; i++) {
+  for (let i = 0; i < queryInfo.length; i += 1) {
     try {
       result.result[queryInfo[i].table_name] = await getInfo(client, queryInfo[i]);
     } catch (error) {
@@ -149,7 +150,8 @@ async function getReference(domainName, pathElements, queryParams, connection) {
     }
   }
 
-  // Tasks and connections class gets their own functions because we have to build the array differently
+  // Tasks and connections class gets their own functions because
+  // we have to build the array differently
   try {
     result.result.task_type = await getTaskType(client);
     result.result.connection_class = await getConnectionClass(client);
@@ -163,7 +165,7 @@ async function getReference(domainName, pathElements, queryParams, connection) {
   // Custom fields also gets its own function because we're creating a map to return
   try {
     result.result.custom_fields = await getCustomFields(client);
-    await client.end()
+    await client.end();
   } catch (error) {
     await client.end();
     result.error = true;

--- a/src/api/lambdas/bedrock-api-backend/reference/handleReference.js
+++ b/src/api/lambdas/bedrock-api-backend/reference/handleReference.js
@@ -3,7 +3,6 @@
 /* eslint-disable no-console */
 import getReference from './getReference.js';
 
-
 // eslint-disable-next-line no-unused-vars
 async function handleReference(
   event,
@@ -11,32 +10,32 @@ async function handleReference(
   queryParams,
   verb,
   connection,
-  ) {
-    let result = {
-      error: false,
-      message: '',
-      result: null,
-    };
-    let nParams = pathElements.length;
-    if (nParams == 2 && (pathElements[1] === null || pathElements[1].length == 0)) nParams = 1;
+) {
+  let result = {
+    error: false,
+    message: '',
+    result: null,
+  };
+  let nParams = pathElements.length;
+  if (nParams === 2 && (pathElements[1] === null || pathElements[1].length == 0)) nParams = 1;
 
-    switch (nParams) {
-      // GET reference
-      case 1:
-        result = await getReference(
-          event.requestContext.domainName,
-          pathElements,
-          queryParams,
-          connection,
-        );
-        break;
-    }
-    if (result.error) {
-      console.log('We have an error but do not know why!');
-      console.log(result.message);
-    }
-  
-    return result;
+  switch (nParams) {
+    // GET reference
+    case 1:
+      result = await getReference(
+        event.requestContext.domainName,
+        pathElements,
+        queryParams,
+        connection,
+      );
+      break;
+  }
+  if (result.error) {
+    console.log('We have an error but do not know why!');
+    console.log(result.message);
+  }
+
+  return result;
 }
 
 export default handleReference;

--- a/src/api/lambdas/bedrock-api-backend/reference/handleReference.js
+++ b/src/api/lambdas/bedrock-api-backend/reference/handleReference.js
@@ -1,3 +1,5 @@
+/* eslint-disable import/extensions */
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getReference from './getReference.js';
 

--- a/src/api/lambdas/bedrock-api-backend/run_groups/addRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/addRunGroup.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, addInfo,

--- a/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkExistence, deleteInfo,

--- a/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroup.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient, getInfo } from '../utilities/utilities.js';
 

--- a/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroupList.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroupList.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient } from '../utilities/utilities.js';
 import {

--- a/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroupList.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroupList.js
@@ -5,7 +5,6 @@ import {
   buildCount, buildOffset, buildWhereClause, getCount, getListInfo, buildURL,
 } from '../utilities/listUtilities.js';
 
-
 async function getRunGroupList(
   domainName,
   pathElements,

--- a/src/api/lambdas/bedrock-api-backend/run_groups/handleRunGroups.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/handleRunGroups.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getRunGroupList from './getRunGroupList.js';
 import getRunGroup from './getRunGroup.js';

--- a/src/api/lambdas/bedrock-api-backend/run_groups/updateRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/updateRunGroup.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, updateInfo,

--- a/src/api/lambdas/bedrock-api-backend/tags/addTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/addTag.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, addInfo,

--- a/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkExistence, deleteInfo,

--- a/src/api/lambdas/bedrock-api-backend/tags/getTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/getTag.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient, getInfo } from '../utilities/utilities.js';
 

--- a/src/api/lambdas/bedrock-api-backend/tags/getTagList.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/getTagList.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import { newClient } from '../utilities/utilities.js';
 import {

--- a/src/api/lambdas/bedrock-api-backend/tags/getTagList.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/getTagList.js
@@ -5,7 +5,6 @@ import {
   buildCount, buildOffset, buildWhereClause, getCount, getListInfo, buildURL,
 } from '../utilities/listUtilities.js';
 
-
 async function getTagList(
   domainName,
   pathElements,

--- a/src/api/lambdas/bedrock-api-backend/tags/handleTags.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/handleTags.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import getTagList from './getTagList.js';
 import getTag from './getTag.js';

--- a/src/api/lambdas/bedrock-api-backend/tags/updateTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/updateTag.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
   newClient, checkInfo, checkExistence, updateInfo,

--- a/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgErrorCodes from '../pgErrorCodes.js';
 

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 const { Client } = pgpkg;

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -1,8 +1,9 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-const { Client } = pgpkg;
 import pgErrorCodes from '../pgErrorCodes.js';
+
+const { Client } = pgpkg;
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);


### PR DESCRIPTION
There were a lot of small lint errors around that I wanted to fix. There are still a few more, but they would require bigger changes and I have other changes I want to make before tackling those.

I added /* eslint-disable import/extensions */ to all the api files, to stop ESLint throwing an error because we have '.js' in the file extension (which is necessary).
