### PR TITLE
Owners filtering on contact_name

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/handler.js
+++ b/src/api/lambdas/bedrock-api-backend/handler.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 // Disabling import/no-unresolved because the dependency as defined
 // in package.json only works in the build subdirectory.

--- a/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
@@ -34,14 +34,6 @@ async function handleOwners(
   if (!(pathElements[1] == null)) {
     [, idValue] = pathElements;
   }
-  // else if (body) { // For POST requests, setting idValue here since it's not in the path
-  //   idValue = body[idField];
-  // }
-
-  // console.log(event);
-  // console.log(JSON.stringify(event));
-  // console.log(pathElements);
-  // console.log(nParams);
 
   switch (nParams) {
     // GET Owners

--- a/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
@@ -38,10 +38,10 @@ async function handleOwners(
   //   idValue = body[idField];
   // }
 
-  console.log(event);
-  console.log(JSON.stringify(event));
-  console.log(pathElements);
-  console.log(nParams);
+  // console.log(event);
+  // console.log(JSON.stringify(event));
+  // console.log(pathElements);
+  // console.log(nParams);
 
   switch (nParams) {
     // GET Owners

--- a/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
@@ -30,6 +30,12 @@ function buildWhereClause(queryParams, idField) {
     whereClause.whereClause += `${where} ${idField} like $1`;
     whereClause.sqlParams.push(`%${queryParams.pattern}%`);
   }
+
+  if ('contact_name' in queryParams) {
+    whereClause.whereClause += `${where} contact_name ilike $1`;
+    const formattedString = queryParams.contact_name.replace(/_/g, ' ');
+    whereClause.sqlParams.push(`%${formattedString}%`);
+  }
   return whereClause;
 }
 


### PR DESCRIPTION
This ended up being easier than anticipated. My brain works so much faster on mondays.

/owners endpoint filters based on contact_name. Underscores in the URL are translated to spaces.
Ex. /owners?contact_name=jon_wilson