### PR TITLE
Removing code that made the api handle underscores as spaces.

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
@@ -30,7 +30,7 @@ function buildWhereClause(queryParams, idField) {
     whereClause.whereClause += `${where} ${idField} like $1`;
     whereClause.sqlParams.push(`%${queryParams.pattern}%`);
   }
-  console.log(queryParams.contact_name);
+
   if ('contact_name' in queryParams) {
     whereClause.whereClause += `${where} contact_name ilike $1`;
     whereClause.sqlParams.push(`%${queryParams.contact_name}%`);

--- a/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
@@ -30,12 +30,12 @@ function buildWhereClause(queryParams, idField) {
     whereClause.whereClause += `${where} ${idField} like $1`;
     whereClause.sqlParams.push(`%${queryParams.pattern}%`);
   }
-
+  console.log(queryParams.contact_name);
   if ('contact_name' in queryParams) {
     whereClause.whereClause += `${where} contact_name ilike $1`;
-    const formattedString = queryParams.contact_name.replace(/_/g, ' ');
-    whereClause.sqlParams.push(`%${formattedString}%`);
+    whereClause.sqlParams.push(`%${queryParams.contact_name}%`);
   }
+
   return whereClause;
 }
 


### PR DESCRIPTION
Removing code that made the api handle underscores as spaces. Not needed.

And API gateway automatically decodes uri, so no need for decodeURIcomponent().