### PR TITLE
Adding ID generation

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkInfo, checkExistence, addInfo,
+  newClient, checkInfo, checkExistence, addInfo, generateId,
 } from '../utilities/utilities.js';
 import pgErrorCodes from '../pgErrorCodes.js';
 
@@ -48,7 +48,6 @@ async function addAssetType(
   allFields,
   body,
   idField,
-  idValue,
   name,
   tableName,
   tableNameCustomFields,
@@ -57,6 +56,8 @@ async function addAssetType(
   const shouldExist = false;
   let client;
   let clientInitiated = false;
+  body.id = generateId();
+  const idValue = body.id;
 
   const response = {
     error: false,

--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -56,8 +56,11 @@ async function addAssetType(
   const shouldExist = false;
   let client;
   let clientInitiated = false;
-  body.id = generateId();
-  const idValue = body.id;
+  const bodyWithID = {
+    ...body,
+    id: generateId(),
+  };
+  const idValue = bodyWithID.id;
 
   const response = {
     error: false,
@@ -68,8 +71,8 @@ async function addAssetType(
   try {
     client = await newClient(connection);
     clientInitiated = true;
-    checkInfo(body, requiredFields, name, idValue, idField);
-    checkCustomFields(body);
+    checkInfo(bodyWithID, requiredFields, name, idValue, idField);
+    checkCustomFields(bodyWithID);
   } catch (error) {
     if (clientInitiated) {
       await client.end();
@@ -82,8 +85,8 @@ async function addAssetType(
   try {
     await client.query('BEGIN');
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    await addCustomFieldsInfo(client, idValue, body);
-    response.result = await addInfo(client, allFields, body, tableName, name);
+    await addCustomFieldsInfo(client, idValue, bodyWithID);
+    response.result = await addInfo(client, allFields, bodyWithID, tableName, name);
     await client.query('COMMIT');
     await client.end();
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
@@ -63,7 +63,6 @@ async function handleAssetTypes(
             allFields,
             body,
             idField,
-            idValue,
             name,
             tableName,
             tableNameCustomFields,

--- a/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
@@ -1,9 +1,7 @@
-/* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import pgpkg from 'pg';
-import pgErrorCodes from '../pgErrorCodes.js';
-
 const { Client } = pgpkg;
+import pgErrorCodes from '../pgErrorCodes.js';
 
 async function newClient(connection) {
   const client = new Client(connection);
@@ -27,7 +25,7 @@ async function readTasks(client, assetName) {
 }
 
 function formatTasks(res) {
-  const tempTasks = [];
+  let tempTasks = [];
   for (let i = 0; i < res.rowCount; i += 1) {
     tempTasks.push(
       {
@@ -69,7 +67,7 @@ async function getTasks(pathElements, queryParams, connection) {
     if (res.rowCount === 0) {
       response.message = 'No tasks found';
     } else {
-      tasks = formatTasks(res);
+      tasks = formatTasks(res)
       response.result = {
         items: tasks,
       };
@@ -80,9 +78,9 @@ async function getTasks(pathElements, queryParams, connection) {
     response.message = error.message;
     return response;
   } finally {
-    await client.end();
+    await client.end()
+    return response;
   }
-  return response;
 }
 
 export default getTasks;

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/addCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/addCustomField.js
@@ -15,8 +15,11 @@ async function addCustomField(
 ) {
   const shouldExist = false;
   let client;
-  body.id = generateId();
-  const idValue = body.id;
+  const bodyWithID = {
+    ...body,
+    id: generateId(),
+  };
+  const idValue = bodyWithID.id;
 
   const response = {
     error: false,
@@ -26,7 +29,7 @@ async function addCustomField(
 
   try {
     client = await newClient(connection);
-    checkInfo(body, requiredFields, name, idValue, idField);
+    checkInfo(bodyWithID, requiredFields, name, idValue, idField);
   } catch (error) {
     response.error = true;
     response.message = error.message;
@@ -34,9 +37,9 @@ async function addCustomField(
   }
 
   try {
-    checkInfo(body, requiredFields, name, idValue, idField);
+    checkInfo(bodyWithID, requiredFields, name, idValue, idField);
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    response.result = await addInfo(client, allFields, body, tableName, idField, idValue, name);
+    response.result = await addInfo(client, allFields, bodyWithID, tableName, idField, idValue, name);
     console.log('finished first insert');
     await client.end();
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/addCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/addCustomField.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkInfo, checkExistence, addInfo,
+  newClient, checkInfo, checkExistence, addInfo, generateId,
 } from '../utilities/utilities.js';
 
 async function addCustomField(
@@ -9,13 +9,14 @@ async function addCustomField(
   allFields,
   body,
   idField,
-  idValue,
   name,
   tableName,
   requiredFields,
 ) {
   const shouldExist = false;
   let client;
+  body.id = generateId();
+  const idValue = body.id;
 
   const response = {
     error: false,

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
@@ -60,7 +60,6 @@ async function handleCustomFields(
             allFields,
             body,
             idField,
-            idValue,
             name,
             tableName,
             requiredFields,

--- a/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
@@ -1,17 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
-import { customAlphabet } from 'nanoid';
 import {
-  newClient, checkInfo, checkExistence, addInfo,
+  newClient, checkInfo, checkExistence, addInfo, generateId,
 } from '../utilities/utilities.js';
-
-function generateId() {
-  const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
-  const nanoid = customAlphabet(alphabet, 16);
-  const thisID = nanoid();
-  return thisID;
-}
 
 async function addOwner(
   connection,

--- a/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
@@ -17,8 +17,11 @@ async function addOwner(
   const shouldExist = false;
   let client;
   let clientInitiated = false;
-  body.owner_id = generateId();
-  const idValue = body.owner_id;
+  const bodyWithID = {
+    ...body,
+    owner_id: generateId(),
+  };
+  const idValue = bodyWithID.owner_id;
 
   const response = {
     error: false,
@@ -29,9 +32,9 @@ async function addOwner(
   try {
     client = await newClient(connection);
     clientInitiated = true;
-    checkInfo(body, requiredFields, name, idValue, idField);
+    checkInfo(bodyWithID, requiredFields, name, idValue, idField);
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    response.result = await addInfo(client, allFields, body, tableName, name);
+    response.result = await addInfo(client, allFields, bodyWithID, tableName, name);
     await client.end();
   } catch (error) {
     if (clientInitiated) {

--- a/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/addOwner.js
@@ -10,7 +10,6 @@ async function addOwner(
   allFields,
   body,
   idField,
-  idValue,
   name,
   tableName,
   requiredFields,
@@ -19,7 +18,7 @@ async function addOwner(
   let client;
   let clientInitiated = false;
   body.owner_id = generateId();
-  idValue = body.owner_id;
+  const idValue = body.owner_id;
 
   const response = {
     error: false,

--- a/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
@@ -57,7 +57,6 @@ async function handleOwners(
             allFields,
             body,
             idField,
-            idValue,
             name,
             tableName,
             requiredFields,

--- a/src/api/lambdas/bedrock-api-backend/tags/addTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/addTag.js
@@ -9,7 +9,6 @@ async function addTag(
   allFields,
   body,
   idField,
-  idValue,
   name,
   tableName,
   requiredFields,
@@ -18,7 +17,7 @@ async function addTag(
   let client;
   let clientInitiated = false;
   body.tag_name = generateId();
-  idValue = body.tag_name;
+  const idValue = body.tag_name;
 
   const response = {
     error: false,

--- a/src/api/lambdas/bedrock-api-backend/tags/addTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/addTag.js
@@ -16,8 +16,11 @@ async function addTag(
   const shouldExist = false;
   let client;
   let clientInitiated = false;
-  body.tag_name = generateId();
-  const idValue = body.tag_name;
+  const bodyWithID = {
+    ...body,
+    tag_name: generateId(),
+  };
+  const idValue = bodyWithID.tag_name;
 
   const response = {
     error: false,
@@ -28,9 +31,9 @@ async function addTag(
   try {
     client = await newClient(connection);
     clientInitiated = true;
-    checkInfo(body, requiredFields, name, idValue, idField);
+    checkInfo(bodyWithID, requiredFields, name, idValue, idField);
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    response.result = await addInfo(client, allFields, body, tableName, name);
+    response.result = await addInfo(client, allFields, bodyWithID, tableName, name);
     await client.end();
   } catch (error) {
     if (clientInitiated) {

--- a/src/api/lambdas/bedrock-api-backend/tags/addTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/addTag.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkInfo, checkExistence, addInfo,
+  newClient, checkInfo, checkExistence, addInfo, generateId,
 } from '../utilities/utilities.js';
 
 async function addTag(
@@ -17,6 +17,8 @@ async function addTag(
   const shouldExist = false;
   let client;
   let clientInitiated = false;
+  body.tag_name = generateId();
+  idValue = body.tag_name;
 
   const response = {
     error: false,

--- a/src/api/lambdas/bedrock-api-backend/tags/handleTags.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/handleTags.js
@@ -64,7 +64,6 @@ async function handleTags(
             allFields,
             body,
             idField,
-            idValue,
             name,
             tableName,
             requiredFields,

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+import { customAlphabet } from 'nanoid';
 import pgpkg from 'pg';
 import pgErrorCodes from '../pgErrorCodes.js';
 
@@ -55,6 +57,13 @@ async function checkExistence(client, tableName, idField, idValue, name, shouldE
   if (!shouldExist && (res.rowCount > 0)) {
     throw new Error(`${capitalizeFirstLetter(name)} like ${idValue} already exists`);
   }
+}
+
+function generateId() {
+  const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+  const nanoid = customAlphabet(alphabet, 16);
+  const thisID = nanoid();
+  return thisID;
 }
 
 async function getInfo(client, idField, idValue, name, tableName) {
@@ -181,4 +190,5 @@ export {
   addInfo,
   updateInfo,
   deleteInfo,
+  generateId,
 };


### PR DESCRIPTION
Adding ID generation to asset_types, custom_fields, and tags endpoints. Turned out to be really easy.

Currently the message returned is, for example,  "Successfully added custom_field a6qYUOLhD_iEP8r2." I want to change the ID to the display name there, but since we're renaming columns soon, I figure I'd do that after that so I don't have to replace column names twice.

I'm also assigning a property of a function parameter (body.id = generateId() for instance in the addAssetType file), which ESLint does not like. I could fix this by creating a new variable from the body, and adding the parameter to that, then passing that to the other functions. It felt kind of silly to create a new variable just for that, but maybe that's a better practice... if you have opinions, let me know, otherwise I'll keep it this way.