### PR TITLE
state machine param one_asset

### DIFF
--- a/src/etl/lambdas/create_etl_run_map/handler.js
+++ b/src/etl/lambdas/create_etl_run_map/handler.js
@@ -251,11 +251,16 @@ const lambda_handler = async function x(event) {
         const errmsg = pgErrorCodes[err.code];
         throw new Error([`Postgres error: ${errmsg}`, err]);
       });
-    let run_groups = [event.run_group];
+    let run_groups = [ event.run_group ];
     if (event.run_group === 'UseCronStrings') {
       run_groups = await getRunGroups(client, debug);
     }
-    let assetMap = await readEtlList(client, run_groups);
+    let assetMap = {};
+    if (event.one_asset) {
+      assetMap = { [event.one_asset]: { name: event.one_asset, run_group: event.run_group, depends: [], etl_tasks: [] } };
+    } else {
+      assetMap = await readEtlList(client, run_groups); 
+    }
     assetMap = await readDependencies(client, assetMap);
     assetMap = await readTasks(client, assetMap);
 

--- a/src/etl/lambdas/create_etl_run_map/local.js
+++ b/src/etl/lambdas/create_etl_run_map/local.js
@@ -1,5 +1,6 @@
 import { lambda_handler } from './handler.js';
-let event = { run_group: 'daily', debug: true };
+// let event = { run_group: 'vxsmart_balances', debug: true };
+let event = { one_asset: 'permit_tasks.lib', debug: true };
 
 await lambda_handler(event);
 

--- a/src/etl/stepfunctions/process_etl_run_group/deploy/states.json
+++ b/src/etl/stepfunctions/process_etl_run_group/deploy/states.json
@@ -10,6 +10,11 @@
           "Variable": "$.run_group",
           "IsPresent": true,
           "Next": "Init"
+        },
+        {
+          "Variable": "$.one_asset",
+          "IsPresent": true,
+          "Next": "Init"
         }
       ],
       "Default": "AddRunGroupFlag"
@@ -24,10 +29,6 @@
       "Comment": "Initialize the run map.",
       "Type": "Task",
       "Resource": "${create_etl_run_map_arn}",
-      "Parameters": {
-        "s3bucket": "managed-data-assets",
-        "run_group.$": "$.run_group"
-      },
       "ResultPath": "$",
       "Next": "Check200"
     },


### PR DESCRIPTION
Allow running a single ETL job, using the state machine parameter like this:
{"one_asset":"ad_info.lib"}