### PR TITLE
using env vars for email recipient

### DIFF
--- a/src/etl/lambdas/etl_email_results/Readme-email recipients.md
+++ b/src/etl/lambdas/etl_email_results/Readme-email recipients.md
@@ -1,5 +1,3 @@
-Email recipients are set in the variable EMAIL_RECIPIENT_JSON
-Sender is set in the variable EMAIL_SENDER
-
-For deployed, set it in the file ./deploy/config.tf
-For local dev, it is set in the file ./makefile
+Email recipient is set in the variable EMAIL_RECIPIENT.
+Sender is set in the variable EMAIL_SENDER.
+Set these in /src/make_variables.

--- a/src/etl/lambdas/etl_email_results/deploy/config.tf
+++ b/src/etl/lambdas/etl_email_results/deploy/config.tf
@@ -23,10 +23,8 @@ resource "aws_lambda_function" "etl_email_results-$$INSTANCE$$" {
     }
     environment {
       variables = {
-          "EMAIL_RECIPIENT_JSON" = jsonencode(
-                ["gisadmins@ashevillenc.gov","jtwilson@ashevillenc.gov"]
-            )
-          "EMAIL_SENDER"         = "asheville_notifications@ashevillenc.gov"
+          "EMAIL_RECIPIENT" = $$EMAIL_RECIPIENT$$
+          "EMAIL_SENDER"    = $$EMAIL_SENDER$$
       }
     }
 }

--- a/src/etl/lambdas/etl_email_results/makefile
+++ b/src/etl/lambdas/etl_email_results/makefile
@@ -35,7 +35,7 @@ node_modules:
 	npm install
 
 local: node_modules
-	EMAIL_RECIPIENT_JSON="[\"jtwilson@ashevillenc.gov\"]" EMAIL_SENDER="asheville_notifications@ashevillenc.gov" node local.js
+	export EMAIL_RECIPIENT=$(EMAIL_RECIPIENT); export EMAIL_SENDER=$(EMAIL_SENDER); node local.js
 
 clean:
 	rm -f *.instance

--- a/src/etl/lambdas/etl_email_results/sendEmails.js
+++ b/src/etl/lambdas/etl_email_results/sendEmails.js
@@ -10,7 +10,8 @@ const compiledFunction = compileFile(join(__dirname, '/email.pug'));
 function sendEmails(results) {
   const totalResults = results?.failure?.length + results?.success?.length + results?.skipped?.length;
   if (totalResults > 0) {
-    let emailAddrs = JSON.parse(process.env.EMAIL_RECIPIENT_JSON);
+    let emailRecip = [process.env.EMAIL_RECIPIENT];
+    let emailSender = process.env.EMAIL_SENDER;
     let htmlEmail, emailSubject;
       results.failure = results.failure.map(res => res.name);
       results.failure.sort();
@@ -25,7 +26,7 @@ function sendEmails(results) {
       let pugObj = {};
       pugObj.results = results;
       htmlEmail = compiledFunction(pugObj);
-      return ses_sendemail(emailAddrs, htmlEmail, emailSubject);
+      return ses_sendemail(emailRecip, emailSender, htmlEmail, emailSubject);
   }else{
     console.log('No email sent');
   }

--- a/src/etl/lambdas/etl_email_results/ses_sendemail.js
+++ b/src/etl/lambdas/etl_email_results/ses_sendemail.js
@@ -2,7 +2,7 @@ import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
 const REGION = "us-east-1";
 const sesClient = new SESClient({ region: REGION });
 
-async function ses_sendemail(emailAddrs, htmlEmail, emailSubject) {
+async function ses_sendemail(emailAddrs, emailSender, htmlEmail, emailSubject) {
   let params = {
     Destination: {
       CcAddresses: [],
@@ -24,9 +24,9 @@ async function ses_sendemail(emailAddrs, htmlEmail, emailSubject) {
         Data: emailSubject
       },
     },
-    Source: process.env.EMAIL_SENDER,
+    Source: emailSender,
     ReplyToAddresses: [
-      process.env.EMAIL_SENDER,
+      emailSender,
     ],
   };
 
@@ -35,7 +35,7 @@ async function ses_sendemail(emailAddrs, htmlEmail, emailSubject) {
   try {
     return await sesClient.send(sendEmailCommand);
   } catch (e) {
-    console.error("Failed to send email.");
+    console.error("Failed to send email.", e);
     return e;
   }
 };

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -2,7 +2,8 @@ INSTANCE = <UNIQUE INSTANCE STRING LIKE ej-test-0: lowercase alphanumeric charac
 region = "us-east-1"
 statebucket = "avl-tfstate-store"
 account = 518970837364
-email_recipients = "['dummy@ashevillenc.gov']"
+EMAIL_SENDER = "asheville_fake@ashevillenc.gov"
+EMAIL_RECIPIENT = "dummy@ashevillenc.gov"
 build_mode = std # Set to sam to build using SAM
 
 # The next four variables provide information on the VPC, subnets and security


### PR DESCRIPTION
Setting up Bedrock email recipients. A long time ago Eric added a variable to make_variables for that, but we never hooked it up. It has been hard coded in Terraform. The tricky part is that it is an array, which was very painful getting to work as a environment variable without lots of complicated and incompatible escaping. Rick mentioned setting up a mailing list, and with just one address we could use a simple string. So meanwhile since I am the only real recipient I'm going to go ahead and drop the array.