### PR TITLE
Updated /tasks to get and update run group

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -52,7 +52,7 @@ async function getCustomFieldInfo(client, assetRows, idValue, requestedFields, o
   return Object.fromEntries(cv.entries());
 }
 
-async function addBaseInfo(assetRows, requestedFields, available) {
+async function getBaseInfo(assetRows, requestedFields, available) {
   const tempAsset = new Map();
   tempAsset.set('asset_name', assetRows[0].asset_name);
   tempAsset.set('asset_type', assetRows[0].asset_type_id);
@@ -81,7 +81,7 @@ async function addBaseInfo(assetRows, requestedFields, available) {
   return tempAsset;
 }
 
-async function addAssetTags(client, idValue) {
+async function getAssetTags(client, idValue) {
   const tags = [];
   const res = await client
     .query('SELECT * from bedrock.asset_tags where asset_id like $1', [idValue])
@@ -131,14 +131,14 @@ async function getAsset(
     const assetRows = await getAssetInfo(client, idValue);
     console.log('after getAssetInfo')
 
-    asset = await addBaseInfo(assetRows, requestedFields, allFields);
+    asset = await getBaseInfo(assetRows, requestedFields, allFields);
     console.log('after Baseinfo')
 
     asset.set('custom_fields', await getCustomFieldInfo(client, assetRows, idValue, requestedFields, overrideFields));
     console.log('after custom fields')
 
     if (requestedFields.includes('tags')) {
-      asset.set('tags', await addAssetTags(client, idValue));
+      asset.set('tags', await getAssetTags(client, idValue));
       console.log('after tags')
 
     }

--- a/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 import pgErrorCodes from '../pgErrorCodes.js';
+import { getInfo } from '../utilities/utilities.js';
 
 const { Client } = pgpkg;
 
@@ -30,7 +31,8 @@ function formatTasks(res) {
   for (let i = 0; i < res.rowCount; i += 1) {
     tempTasks.push(
       {
-        asset_name: res.rows[i].asset_name,
+        task_id: res.rows[i].task_id,
+        asset_id: res.rows[i].asset_id,
         seq_number: res.rows[i].seq_number,
         description: res.rows[i].description,
         type: res.rows[i].type,
@@ -44,7 +46,7 @@ function formatTasks(res) {
   return tempTasks;
 }
 
-async function getTasks(connection, idValue) {
+async function getTasks(connection, idValue, idField, name) {
   const response = {
     error: false,
     message: '',
@@ -53,6 +55,7 @@ async function getTasks(connection, idValue) {
   let client;
   let res;
   let tasks = [];
+  let runGroup;
 
   try {
     client = await newClient(connection);
@@ -64,12 +67,15 @@ async function getTasks(connection, idValue) {
 
   try {
     res = await readTasks(client, idValue);
+    runGroup = await getInfo(client, idField, idValue, name, 'bedrock.etl')
+    console.log(runGroup)
     if (res.rowCount === 0) {
       response.message = 'No tasks found';
     } else {
       tasks = formatTasks(res);
       response.result = {
         items: tasks,
+        run_group: {run_group_id: runGroup.run_group_id, active: runGroup.active}
       };
     }
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getTasks.js
@@ -68,7 +68,6 @@ async function getTasks(connection, idValue, idField, name) {
   try {
     res = await readTasks(client, idValue);
     runGroup = await getInfo(client, idField, idValue, name, 'bedrock.etl')
-    console.log(runGroup)
     if (res.rowCount === 0) {
       response.message = 'No tasks found';
     } else {

--- a/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
@@ -117,7 +117,7 @@ async function handleAssets(event, pathElements, queryParams, verb, connection) 
     case 3:
       if (pathElements[2] === 'tasks') {
         if (verb === 'GET') {
-          response = await getTasks(connection, idValue);
+          response = await getTasks(connection, idValue, idField, name);
         } else if (verb === 'PUT') {
           response = await updateTasks(
             connection,

--- a/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
@@ -46,10 +46,6 @@ async function addTasks(client, allFields, body) {
       }
     });
 
-    console.log(fieldsString)
-      console.log(valuesFromBody)
-    
-
     try {
       await client
         .query(`INSERT INTO bedrock.tasks ${fieldsString} VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`, valuesFromBody);
@@ -92,7 +88,6 @@ async function updateTasks(
     await client.query('BEGIN');
     await deleteInfo(client, tableName, idField, idValue, name);
     await addTasks(client, allFields, body);
-    console.log('past addtasks')
     await updateInfo(client, ['asset_id', 'run_group_id', 'active'], body, 'bedrock.etl', idField, idValue, name)
     await client.query('COMMIT');
     response.result = body;

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -76,6 +76,8 @@ async function getInfo(client, idField, idValue, name, tableName) {
   } catch (error) {
     throw new Error([`Postgres error: ${pgErrorCodes[error.code]||error.code}`, error]);
   }
+  console.log(res)
+  console.log(res.rows[0])
 
   if (res.rowCount === 0) {
     throw new Error(`${capitalizeFirstLetter(name)} not found`);
@@ -149,10 +151,14 @@ async function updateInfo(client, allFields, body, tableName, idField, idValue, 
 
   // Creating a string like 'tag_name = $1, display_name = 2$' etc
   // and adding the actual value to the args array
-  Object.keys(body).forEach((key) => {
+  Object.keys(body.run_group).forEach((key) => {
     if (allFields.includes(key)) {
+      if (key == 'asset_id') {
+        sql += `${comma} ${key} = $${cnt}`;
+        args.push(idValue);
+      }
       sql += `${comma} ${key} = $${cnt}`;
-      args.push(body[key]);
+      args.push(body.run_group[key]);
       cnt += 1;
       comma = ',';
     }
@@ -160,6 +166,9 @@ async function updateInfo(client, allFields, body, tableName, idField, idValue, 
 
   sql += ` where ${idField} = $${cnt}`;
   args.push(idValue);
+
+  console.log(sql)
+  console.log(args)
   try {
     await client.query(sql, args);
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -12,11 +12,9 @@ function capitalizeFirstLetter(string) {
 }
 
 async function newClient(connection) {
-  console.log('in new client')
   const client = new Client(connection);
   try {
     await client.connect();
-    console.log('after client.connect')
 
     return client;
   } catch (error) {
@@ -76,8 +74,6 @@ async function getInfo(client, idField, idValue, name, tableName) {
   } catch (error) {
     throw new Error([`Postgres error: ${pgErrorCodes[error.code]||error.code}`, error]);
   }
-  console.log(res)
-  console.log(res.rows[0])
 
   if (res.rowCount === 0) {
     throw new Error(`${capitalizeFirstLetter(name)} not found`);
@@ -167,8 +163,6 @@ async function updateInfo(client, allFields, body, tableName, idField, idValue, 
   sql += ` where ${idField} = $${cnt}`;
   args.push(idValue);
 
-  console.log(sql)
-  console.log(args)
   try {
     await client.query(sql, args);
   } catch (error) {
@@ -192,7 +186,6 @@ async function deleteInfo(client, tableName, idField, idValue, name) {
 async function addAssetTypeCustomFields(client, idValue, body) {
   let res;
   const valueStrings = [];
-  console.log(body.custom_fields);
 
   body.custom_fields.forEach((obj) => {
     const customFieldId = Object.keys(obj);
@@ -200,9 +193,6 @@ async function addAssetTypeCustomFields(client, idValue, body) {
     valueStrings.push(`('${idValue}', '${customFieldId}', ${required})`);
   });
   const combinedValueString = valueStrings.join(', ');
-  console.log(valueStrings);
-  console.log(`INSERT INTO bedrock.asset_type_custom_fields (asset_type_id, custom_field_id, required) VALUES ${combinedValueString}`,
-);
 
   try {
     res = await client
@@ -212,11 +202,7 @@ async function addAssetTypeCustomFields(client, idValue, body) {
   } catch (error) {
     throw new Error([`Postgres error: ${pgErrorCodes[error.code]}`, error]);
   }
-  console.log(res);
-  // if (res.rowCount !== 1) {
-  //   throw new Error(`Unknown error inserting new ${name}`);
-  // }
-  console.log('end of customfieldsadding');
+
   return body.custom_fields;
 }
 


### PR DESCRIPTION
You can now change an asset's run group through the asset/<asset_id>/tasks endpoint.

You can also still do it through the normal /assets endpoint as well. If you think I should remove managing it there, or have it throw an error if it's changed through an /assets PUT request, let me know- I just kept it in for flexibility.

(Also snuck in a little bit of clean up in some other files)