### PR TITLE
db schema name as a variable

### DIFF
--- a/src/etl/lambdas/create_etl_run_map/deploy/config.tf
+++ b/src/etl/lambdas/create_etl_run_map/deploy/config.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "create_etl_run_map-$$INSTANCE$$" {
     environment {
       variables = {
         BEDROCK_DB_HOST = $$BEDROCK_DB_HOST$$
+        BEDROCK_DB_SCHEMA = $$BEDROCK_DB_SCHEMA$$
       }
     }
 }

--- a/src/etl/lambdas/create_etl_run_map/makefile
+++ b/src/etl/lambdas/create_etl_run_map/makefile
@@ -36,6 +36,7 @@ node_modules:
 
 local: node_modules
 	@export BEDROCK_DB_HOST=$(BEDROCK_DB_HOST);export BEDROCK_DB_USER=$(BEDROCK_DB_USER); \
+	export BEDROCK_DB_SCHEMA=$(BEDROCK_DB_SCHEMA) \
 	export BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD);export BEDROCK_DB_NAME=$(BEDROCK_DB_NAME);node local.js
 
 clean:

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -23,6 +23,9 @@ BEDROCK_DB_USER=
 BEDROCK_DB_PASSWORD=
 BEDROCK_DB_NAME=
 
+# Unlike the other DB variables, always include a schema name.
+BEDROCK_DB_SCHEMA="bedrock"
+
 # This is used in the API. The value can be read from 
 # src/etl/stepfunctions/process_etl_run_group/state_machine_variables.generated 
 # after creating the step function.


### PR DESCRIPTION
I did not include the new variable in API, on the assumption that this is just a temporary work-around to accommodate old-style db ETL before API golive.