### PR TITLE
move step func generated file

### DIFF
--- a/docs/deploy-notes.md
+++ b/docs/deploy-notes.md
@@ -53,7 +53,7 @@ make init
 make apply
 ```
 
-The API depends on the make_variable value STATE_MACHINE_ARN which was exported in the previous step. It can be found in the generated file: `src/etl/stepfunctions/process_etl_run_group/state_machine_variables.generated`
+The API depends on the make_variable value STATE_MACHINE_ARN which was exported in the previous step. It can be found in the generated file: `src/etl/state_machine_variables.generated`
 Copy that to the make_variables file and then run this to create the API:
 
 ``` sh

--- a/src/etl/stepfunctions/process_etl_run_group/deploy/makefile
+++ b/src/etl/stepfunctions/process_etl_run_group/deploy/makefile
@@ -19,12 +19,12 @@ plan: terraform.tfvars $(config_files)
 .PHONY: apply
 apply: terraform.tfvars $(config_files)
 	terraform apply
-	echo STATE_MACHINE_ARN=`terraform output -json process_etl_run_group_arn` > ../state_machine_variables.generated
+	echo STATE_MACHINE_ARN=`terraform output -json process_etl_run_group_arn` > ../../../state_machine_variables.generated
 
 .PHONY: apply-y
 apply-y: terraform.tfvars $(config_files)
 	terraform apply -auto-approve
-	echo STATE_MACHINE_ARN=`terraform output -json process_etl_run_group_arn` > ../state_machine_variables.generated
+	echo STATE_MACHINE_ARN=`terraform output -json process_etl_run_group_arn` > ../../../state_machine_variables.generated
 
 .PHONY: destroy
 destroy: terraform.tfvars $(config_files)

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -27,7 +27,7 @@ BEDROCK_DB_NAME=
 BEDROCK_DB_SCHEMA="bedrock"
 
 # This is used in the API. The value can be read from 
-# src/etl/stepfunctions/process_etl_run_group/state_machine_variables.generated 
+# src/etl/state_machine_variables.generated 
 # after creating the step function.
 STATE_MACHINE_ARN = "arn:aws:xxx"
 


### PR DESCRIPTION
To be more consistent with the other generated files, this one now appears in the /etl dir, which is where you would normally call it from when creating a full etl application.