### PR TITLE
Changes from deletion discussion

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -1,9 +1,8 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkInfo, checkExistence, addInfo, generateId,
+  newClient, checkInfo, checkExistence, addInfo, generateId, addAssetTypeCustomFields
 } from '../utilities/utilities.js';
-import { addAssetTypeCustomFields } from '../utilities/utilities.js'
 
 function checkCustomFields(body) {
   if (body.custom_fields) {

--- a/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkExistence, deleteInfo,
+  newClient, checkExistence, deleteInfo, checkBeforeDelete
 } from '../utilities/utilities.js';
 
 async function deleteAssetType(
@@ -14,6 +14,9 @@ async function deleteAssetType(
 ) {
   const shouldExist = true;
   let client;
+  const assetsTableName = 'bedrock.assets';
+  const connectedData = 'assets';
+  const connectedDataIdField = 'asset_id'
 
   const response = {
     error: false,
@@ -31,6 +34,7 @@ async function deleteAssetType(
 
   try {
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
+    await checkBeforeDelete(client, name, assetsTableName, idField, idValue, connectedData, connectedDataIdField)
     await client.query('BEGIN');
     await deleteInfo(client, tableName, idField, idValue, name);
     await deleteInfo(client, tableNameCustomFields, 'asset_type_id', idValue, name);

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getAssetType.js
@@ -36,7 +36,8 @@ async function getAssetType(
     client = await newClient(connection);
     clientInitiated = true;
     response.result = await getInfo(client, idField, idValue, name, tableName);
-    const customFieldsResponse = await getBaseCustomFieldsInfo(client, idField, idValue, name, tableNameCustomFields);
+    const customFieldsResponse = await getBaseCustomFieldsInfo(client, idField, idValue, name, tableNameCustomFields)
+    console.log(customFieldsResponse)
     response.result.custom_fields = simpleFormatCustomFields(customFieldsResponse);
     await client.end();
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getAssetType.js
@@ -37,7 +37,6 @@ async function getAssetType(
     clientInitiated = true;
     response.result = await getInfo(client, idField, idValue, name, tableName);
     const customFieldsResponse = await getBaseCustomFieldsInfo(client, idField, idValue, name, tableNameCustomFields)
-    console.log(customFieldsResponse)
     response.result.custom_fields = simpleFormatCustomFields(customFieldsResponse);
     await client.end();
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getAssetTypeList.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getAssetTypeList.js
@@ -1,11 +1,9 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
-import { newClient, getBaseCustomFieldsInfo, getAncestorCustomFieldsInfo, formatCustomFields } from '../utilities/utilities.js';
+import { newClient, getBaseCustomFieldsInfo } from '../utilities/utilities.js';
 import {
   buildCount, buildOffset, buildWhereClause, getCount, getListInfo, buildURL,
 } from '../utilities/listUtilities.js';
-import pgErrorCodes from '../pgErrorCodes.js';
-
 
 async function getAssetTypeList(
   domainName,
@@ -49,8 +47,7 @@ async function getAssetTypeList(
     for (const item of response.result.items) {
       const asset_type_id = item.asset_type_id
       const customFieldsResponse = await getBaseCustomFieldsInfo(client, idField, asset_type_id, name, tableNameCustomFields);
-      const ancestorCustomFields = await getAncestorCustomFieldsInfo(client, asset_type_id);
-      item.custom_fields = formatCustomFields(customFieldsResponse, ancestorCustomFields) || {};
+      item.custom_fields = Object.fromEntries(customFieldsResponse) || {};
     }
     
     await client.end();

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getRichCustomFields.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getRichCustomFields.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
-import { newClient, capitalizeFirstLetter, getBaseCustomFieldsInfo, getAncestorCustomFieldsInfo, formatCustomFields } from '../utilities/utilities.js';
+import { newClient, getBaseCustomFieldsInfo, } from '../utilities/utilities.js';
 
 async function getRichCustomFields(
   connection,
@@ -22,8 +22,7 @@ async function getRichCustomFields(
     client = await newClient(connection);
     clientInitiated = true;
     const customFieldsResponse = await getBaseCustomFieldsInfo(client, idField, idValue, name, tableNameCustomFields);
-    const ancestorCustomFields = await getAncestorCustomFieldsInfo(client, idValue);
-    response.result.items = formatCustomFields(customFieldsResponse, ancestorCustomFields) || {};
+    response.result.items = Object.fromEntries(customFieldsResponse) || {};
     await client.end();
   } catch (error) {
     if (clientInitiated) {

--- a/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
@@ -28,7 +28,7 @@ async function handleAssetTypes(
   const name = 'asset type';
   const tableName = 'bedrock.asset_types';
   const requiredFields = ['asset_type_id', 'asset_type_name'];
-  const allFields = ['asset_type_id', 'asset_type_name', 'parent'];
+  const allFields = ['asset_type_id', 'asset_type_name'];
   const tableNameCustomFields = 'bedrock.asset_type_custom_fields';
 
   if (nParams === 2 && (pathElements[1] === null || pathElements[1].length === 0)) nParams = 1;

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -134,10 +134,7 @@ async function addAsset(
   };
   bodyWithID[idField] = generateId();
   const idValue = bodyWithID[idField];
-
   let customFields = new Map(Object.entries(bodyWithID.custom_fields));
-
-  console.log(customFields)
 
   const response = {
     error: false,
@@ -154,19 +151,15 @@ async function addAsset(
   }
 
   await client.query('BEGIN');
-  console.log(bodyWithID);
 
   try {
-    // await checkExistence(client, idValue);
     checkExistence(client, tableName, idField, idValue, name, shouldExist);
     checkInfo(bodyWithID, requiredFields, name, idValue, idField);
     customFieldsFromAssetType = await getCustomFieldsInfo(client, bodyWithID.asset_type_id);
-    // customValues are from body
+    // customValues are from body, not CV table
     customValues = getCustomValues(bodyWithID);
     checkCustomFieldsInfo(body, customFieldsFromAssetType);
     asset = await baseInsert(bodyWithID, client);
-    console.log('logging custom_fields')
-    console.log(customFields)
     const updatedCustomFields = await addCustomFieldsInfo(bodyWithID, client, customFields, customValues);
     asset.set('custom_fields', Object.fromEntries(updatedCustomFields));
     asset.set('parents', await addDependencies(bodyWithID, client));

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -11,14 +11,7 @@ async function handleDelete(tableNames, client, idField, idValue, name) {
       const data = await deleteInfo(client, table, idField, idValue, name);
       return data;
     });
-
-    // Wait for all promises to resolve concurrently
-    const results = await Promise.all(promises);
-
-    // Process the results
-    console.log(results);
   } catch (error) {
-    // Handle any errors that occurred during the asynchronous operations
     console.error('Error fetching data:', error);
   }
 }
@@ -53,7 +46,7 @@ async function deleteAsset(
 
   try {
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    // the two ID fields in the next line seemed to be switched, but they are correct- the naming convention in the
+    // the two ID fields in the next line seem to be switched, but they are correct- the naming convention in the
     //dependency table makes it a bit confusing (we want to check if asset is in the "dependent_asset_id colum",
     // not the "asset_id" column)
     await checkBeforeDelete(client, name, dependencyTableName, connectedDataIdField, idValue, connectedData, idField)

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 import pgErrorCodes from '../pgErrorCodes.js';
-import { newClient, checkExistence, deleteInfo } from '../utilities/utilities.js';
+import { newClient, checkExistence, deleteInfo, checkBeforeDelete } from '../utilities/utilities.js';
 
 async function handleDelete(tableNames, client, idField, idValue, name) {
   try {
@@ -33,6 +33,9 @@ async function deleteAsset(
   let client;
   const shouldExist = true;
   const tableNames = ['bedrock.assets', 'bedrock.custom_values', 'bedrock.asset_tags', 'bedrock.dependencies', 'bedrock.tasks'];
+  const dependencyTableName = 'bedrock.dependencies';
+  const connectedData = 'dependent assets';
+  const connectedDataIdField = 'dependent_asset_id';
   // no need for building a map object to send to the requester, as we only return the asset name.
   const response = {
     error: false,
@@ -50,6 +53,7 @@ async function deleteAsset(
 
   try {
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
+    await checkBeforeDelete(client, name, dependencyTableName, idField, idValue, connectedData, connectedDataIdField)
   } catch (error) {
     await client.end();
     response.error = true;

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -53,7 +53,10 @@ async function deleteAsset(
 
   try {
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    await checkBeforeDelete(client, name, dependencyTableName, idField, idValue, connectedData, connectedDataIdField)
+    // the two ID fields in the next line seemed to be switched, but they are correct- the naming convention in the
+    //dependency table makes it a bit confusing (we want to check if asset is in the "dependent_asset_id colum",
+    // not the "asset_id" column)
+    await checkBeforeDelete(client, name, dependencyTableName, connectedDataIdField, idValue, connectedData, idField)
   } catch (error) {
     await client.end();
     response.error = true;

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -28,10 +28,10 @@ async function getCustomFieldInfo(client, assetRows, idValue, requestedFields, o
   // this function is different than getCustomFieldsInfo in assetUtilities. This one queries from
   // the custom_values table, while the other builds a list of needed customfields based on
   // asset type.
-  const cv = new Map();
-  if (assetRows.asset_type_id !== null) {
+  const customValues = new Map();
+  if (assetRows[0].asset_type_id !== null) {
     let res;
-    const sql = 'SELECT custom_field_id, field_value from bedrock.custom_values where asset_id like $1';
+    let sql = 'SELECT custom_field_id, field_value from bedrock.custom_values where asset_id like $1';
     try {
       res = await client.query(sql, [idValue]);
     } catch (error) {
@@ -43,12 +43,33 @@ async function getCustomFieldInfo(client, assetRows, idValue, requestedFields, o
     if (res.rowCount > 0) {
       for (let i = 0; i < res.rowCount; i += 1) {
         if (!overrideFields || requestedFields.includes(res.rows[i].field_name)) {
-          cv.set(res.rows[i].custom_field_id, res.rows[i].field_value);
+          customValues.set(res.rows[i].custom_field_id, res.rows[i].field_value);
         }
       }
     }
+    console.log(assetRows[0].asset_type_id)
+    sql = 'SELECT * from bedrock.asset_type_custom_fields where asset_type_id like $1';
+    try {
+      res = await client.query(sql, [assetRows[0].asset_type_id]);
+    } catch (error) {
+      console.log(`PG error getting custom fields: ${pgErrorCodes[error.code]||error.code}`);
+      throw new Error(
+        `PG error getting custom fields: ${pgErrorCodes[error.code]}`,
+      );
+    }
+
+    res.rows.forEach((item) => {
+      if (!customValues.has(item.asset_type_id)) {
+        customValues.set(item.asset_type_id, null)
+      }
+    })
+    console.log('logging res')
+    console.log(res)
+  console.log(customValues)
+
+
   }
-  return Object.fromEntries(cv.entries());
+  return Object.fromEntries(customValues.entries());
 }
 
 async function getBaseInfo(assetRows, requestedFields, available) {
@@ -126,6 +147,8 @@ async function getAsset(
 
   try {
     const assetRows = await getAssetInfo(client, idValue);
+    console.log('getting asset_rows')
+    console.log(assetRows)
     console.log('after getAssetInfo')
 
     asset = await getBaseInfo(assetRows, requestedFields, allFields);

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -57,10 +57,10 @@ async function getCustomFieldInfo(client, assetRows, idValue, requestedFields, o
         `PG error getting custom fields: ${pgErrorCodes[error.code]}`,
       );
     }
-
+    console.log(res)
     res.rows.forEach((item) => {
-      if (!customValues.has(item.asset_type_id)) {
-        customValues.set(item.asset_type_id, null)
+      if (!customValues.has(item.custom_field_id)) {
+        customValues.set(item.custom_field_id, null)
       }
     })
     console.log('logging res')

--- a/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAsset.js
@@ -47,7 +47,6 @@ async function getCustomFieldInfo(client, assetRows, idValue, requestedFields, o
         }
       }
     }
-    console.log(assetRows[0].asset_type_id)
     sql = 'SELECT * from bedrock.asset_type_custom_fields where asset_type_id like $1';
     try {
       res = await client.query(sql, [assetRows[0].asset_type_id]);
@@ -57,17 +56,11 @@ async function getCustomFieldInfo(client, assetRows, idValue, requestedFields, o
         `PG error getting custom fields: ${pgErrorCodes[error.code]}`,
       );
     }
-    console.log(res)
     res.rows.forEach((item) => {
       if (!customValues.has(item.custom_field_id)) {
         customValues.set(item.custom_field_id, null)
       }
     })
-    console.log('logging res')
-    console.log(res)
-  console.log(customValues)
-
-
   }
   return Object.fromEntries(customValues.entries());
 }
@@ -133,34 +126,21 @@ async function getAsset(
     message: '',
     result: null,
   };
-  console.log('very beginning')
+
   try {
     client = await newClient(connection);
-    console.log('past clinet0')
   } catch (error) {
     response.error = true;
     response.message = error.message;
     return response;
   }
 
-  console.log('begin')
-
   try {
     const assetRows = await getAssetInfo(client, idValue);
-    console.log('getting asset_rows')
-    console.log(assetRows)
-    console.log('after getAssetInfo')
-
     asset = await getBaseInfo(assetRows, requestedFields, allFields);
-    console.log('after Baseinfo')
-
     asset.set('custom_fields', await getCustomFieldInfo(client, assetRows, idValue, requestedFields, overrideFields));
-    console.log('after custom fields')
-
     if (requestedFields.includes('tags')) {
       asset.set('tags', await getAssetTags(client, idValue));
-      console.log('after tags')
-
     }
     response.result = Object.fromEntries(asset.entries());
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
@@ -115,11 +115,13 @@ async function updateAsset(
   allFields,
   body,
 ) {
-  let customFields;
+  let customFieldsFromAssetType;
   let customValues;
   let client;
   const baseFields = ['asset_id', 'asset_name', 'description', 'location', 'active', 'owner_id', 'asset_type_id', 'location', 'link', 'notes'];
   const assetType = body.asset_type_id;
+  let customFields = new Map(Object.entries(body.custom_fields));
+
 
   const response = {
     error: false,
@@ -142,9 +144,10 @@ async function updateAsset(
     await checkExistence(client, idValue);
     await updateInfo(client, baseFields, body, tableName, idField, idValue, name);
     if (assetType) {
-      customFields = await getCustomFieldsInfo(client, body.asset_type_id);
+      customFieldsFromAssetType = await getCustomFieldsInfo(client, body.asset_type_id);
+      // CVs are from body, not CVs table!
       customValues = getCustomValues(body);
-      checkCustomFieldsInfo(body, customFields);
+      checkCustomFieldsInfo(body, customFieldsFromAssetType);
       await deleteInfo(client, 'bedrock.custom_values', idField, idValue, name);
       await addCustomFieldsInfo(body, client, customFields, customValues);
     }

--- a/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
@@ -16,7 +16,6 @@ function checkInfo(body, requiredFields) {
 }
 
 async function updateETLInfo(client, allFields, body, tableName, idField, idValue, name) {
-  console.log('inside')
   let cnt = 1;
   const args = [];
   let sql = `UPDATE ${tableName} SET `;
@@ -25,10 +24,8 @@ async function updateETLInfo(client, allFields, body, tableName, idField, idValu
   // Creating a string like 'tag_name = $1, display_name = 2$' etc
   // and adding the actual value to the args array
   Object.keys(body.run_group).forEach((key) => {
-    console.log('inside forEach')
 
     if (allFields.includes(key)) {
-      console.log('inside includes')
 
       if (key == 'asset_id') {
         sql += `${comma} ${key} = $${cnt}`;
@@ -49,8 +46,6 @@ async function updateETLInfo(client, allFields, body, tableName, idField, idValu
   } catch (error) {
     throw new Error(`PG error updating ${name}: ${pgErrorCodes[error.code]||error.code}`);
   }
-
-  console.log('after query')
 
   return body;
 }

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
@@ -14,10 +14,13 @@ async function deleteCustomField(
   const shouldExist = true;
   let client;
   let clientInitiated = false;
+  // We're only deleting the relationships between CFs and asset_types, not the actual CFs. 
+  // which is why we're using a different table name.
+  const linkingTableName = 'bedrock.asset_type_custom_fields'
 
   const response = {
     error: false,
-    message: `Successfully deleted ${name} ${idValue}`,
+    message: `Successfully deleted relationship between ${name} ${idValue} and asset_types.`,
     result: null,
   };
 
@@ -25,7 +28,7 @@ async function deleteCustomField(
     client = await newClient(connection);
     clientInitiated = true;
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    await deleteInfo(client, tableName, idField, idValue, name);
+    await deleteInfo(client, linkingTableName, idField, idValue, name);
     await client.end();
   } catch (error) {
     if (clientInitiated) {

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
@@ -20,7 +20,7 @@ async function deleteCustomField(
 
   const response = {
     error: false,
-    message: `Successfully deleted relationship between ${name} ${idValue} and asset_types.`,
+    message: `Successfully deleted relationship between ${name} ${idValue} and corresponding asset_type(s).`,
     result: null,
   };
 

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
@@ -22,7 +22,7 @@ async function handleCustomFields(
   let body;
   const idField = 'custom_field_id';
   let idValue;
-  const name = 'custom_fields';
+  const name = 'custom_field';
   const tableName = 'bedrock.custom_fields';
   const requiredFields = ['custom_field_id', 'custom_field_name', 'field_type', 'field_data'];
   const allFields = ['custom_field_id', 'custom_field_name', 'field_type', 'field_data'];

--- a/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkExistence, deleteInfo,
+  newClient, checkExistence, deleteInfo, checkBeforeDelete,
 } from '../utilities/utilities.js';
 
 async function deleteOwner(
@@ -14,6 +14,9 @@ async function deleteOwner(
   const shouldExist = true;
   let client;
   let clientInitiated = false;
+  const assetsTableName = 'bedrock.assets';
+  const connectedData = 'assets';
+  const connectedDataIdField = 'asset_id'
 
   const response = {
     error: false,
@@ -25,6 +28,7 @@ async function deleteOwner(
     client = await newClient(connection);
     clientInitiated = true;
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
+    await checkBeforeDelete(client, name, assetsTableName, idField, idValue, connectedData, connectedDataIdField)
     await deleteInfo(client, tableName, idField, idValue, name);
     await client.end();
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/reference/getReference.js
+++ b/src/api/lambdas/bedrock-api-backend/reference/getReference.js
@@ -87,7 +87,6 @@ async function getCustomFields(client) {
     throw new Error(`PG error getting asset types: ${pgErrorCodes[error.code]||error.code}`);
   }
   let type;
-  console.log(types)
   for (type of types) {
     const customFields = await getCustomFieldsInfo(client, type);
     const typeMap = resultMap.get(type);

--- a/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  newClient, checkExistence, deleteInfo,
+  newClient, checkExistence, deleteInfo, checkBeforeDelete,
 } from '../utilities/utilities.js';
 
 async function deleteRunGroup(
@@ -14,6 +14,9 @@ async function deleteRunGroup(
   const shouldExist = true;
   let client;
   let clientInitiated = false;
+  const etlTableName = 'bedrock.etl'
+  const connectedData = 'assets'
+  const connectedDataIdField = 'asset_id'
 
   const response = {
     error: false,
@@ -25,6 +28,7 @@ async function deleteRunGroup(
     client = await newClient(connection);
     clientInitiated = true;
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
+    await checkBeforeDelete(client, name, etlTableName, idField, idValue, connectedData, connectedDataIdField)
     await deleteInfo(client, tableName, idField, idValue, name);
     await client.end();
   } catch (error) {

--- a/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroup.js
@@ -38,7 +38,6 @@ async function getRunGroup(
     clientInitiated = true;
     response.result = await getInfo(client, idField, idValue, name, tableName);
     const assetInfo = await getAssetInfo(client, idValue, name);
-    console.log(assetInfo);
     response.result.assets = [];
     assetInfo.rows.forEach((obj) => {
       response.result.assets.push({ asset_name: obj.asset_name, display_name: obj.display_name }); 

--- a/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
@@ -14,6 +14,7 @@ async function deleteTag(
   const shouldExist = true;
   let client;
   let clientInitiated = false;
+  const linkingTableName = 'bedrock.asset_tags'
 
   const response = {
     error: false,
@@ -26,6 +27,7 @@ async function deleteTag(
     clientInitiated = true;
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
     await deleteInfo(client, tableName, idField, idValue, name);
+    await deleteInfo(client, linkingTableName, idField, idValue, name);
     await client.end();
   } catch (error) {
     if (clientInitiated) {

--- a/src/api/lambdas/bedrock-api-backend/utilities/assetUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/assetUtilities.js
@@ -15,37 +15,12 @@ function calculateRequestedFields(queryParams, allFields) {
   return requestedFields;
 }
 
-async function getCustomFieldsInfo(client, asset_type) {
+async function getCustomFieldsInfo(client, assetType) {
+  console.log(assetType)
   let sqlQuery;
   let sqlResult;
-  // let types = '';
   const customFields = new Map();
   try {
-  //   // Get the asset type hierarchy
-  //   sqlQuery = `
-  //     WITH RECURSIVE ancestors AS (
-  //       SELECT asset_type_id, parent, asset_type_name FROM bedrock.asset_types
-  //       WHERE asset_type_id = $1
-  //       UNION
-  //         SELECT t.asset_type_id, t.parent, t.asset_type_name
-  //         FROM bedrock.asset_types t
-  //         INNER JOIN ancestors a ON a.parent = t.asset_type_id
-  //     ) SELECT * FROM ancestors;
-  //   `;
-  //   console.log(sqlQuery)
-  //   console.log(asset_type)
-  //   sqlResult = await client.query(sqlQuery, [asset_type]);
-  //   if (sqlResult.rowCount < 1) {
-  //     throw new Error(`Asset type ${asset_type} not found`);
-  //   }
-  //   sqlResult.rows.forEach((itm, i) => {
-  //     const comma = i > 0 ? ',' : '';
-  //     types = `${types}${comma} '${itm.asset_type_id}'`;
-  //   });
-  //   console.log(sqlResult)
-  //   console.log(types)
-    // Now get custom fields associated with any of the types
-    // Field is required if any type in the hierarchy requires it
     sqlQuery = `
       select custom_field_id, custom_field_name, field_type, bool_or(required) as required
       from (
@@ -56,7 +31,7 @@ async function getCustomFieldsInfo(client, asset_type) {
       ) a
       group by custom_field_id, custom_field_name, field_type
     `;
-    sqlResult = await client.query(sqlQuery, [asset_type]);
+    sqlResult = await client.query(sqlQuery, [assetType]);
       console.log(sqlResult)
 
     sqlResult.rows.forEach((itm) => {

--- a/src/api/lambdas/bedrock-api-backend/utilities/assetUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/assetUtilities.js
@@ -16,7 +16,6 @@ function calculateRequestedFields(queryParams, allFields) {
 }
 
 async function getCustomFieldsInfo(client, assetType) {
-  console.log(assetType)
   let sqlQuery;
   let sqlResult;
   const customFields = new Map();
@@ -32,8 +31,6 @@ async function getCustomFieldsInfo(client, assetType) {
       group by custom_field_id, custom_field_name, field_type
     `;
     sqlResult = await client.query(sqlQuery, [assetType]);
-      console.log(sqlResult)
-
     sqlResult.rows.forEach((itm) => {
       customFields.set(itm.custom_field_id, itm);
     });

--- a/src/api/lambdas/bedrock-api-backend/utilities/assetUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/assetUtilities.js
@@ -18,32 +18,32 @@ function calculateRequestedFields(queryParams, allFields) {
 async function getCustomFieldsInfo(client, asset_type) {
   let sqlQuery;
   let sqlResult;
-  let types = '';
+  // let types = '';
   const customFields = new Map();
   try {
-    // Get the asset type hierarchy
-    sqlQuery = `
-      WITH RECURSIVE ancestors AS (
-        SELECT asset_type_id, parent, asset_type_name FROM bedrock.asset_types
-        WHERE asset_type_id = $1
-        UNION
-          SELECT t.asset_type_id, t.parent, t.asset_type_name
-          FROM bedrock.asset_types t
-          INNER JOIN ancestors a ON a.parent = t.asset_type_id
-      ) SELECT * FROM ancestors;
-    `;
-    console.log(sqlQuery)
-    console.log(asset_type)
-    sqlResult = await client.query(sqlQuery, [asset_type]);
-    if (sqlResult.rowCount < 1) {
-      throw new Error(`Asset type ${asset_type} not found`);
-    }
-    sqlResult.rows.forEach((itm, i) => {
-      const comma = i > 0 ? ',' : '';
-      types = `${types}${comma} '${itm.asset_type_id}'`;
-    });
-    console.log(sqlResult)
-    console.log(types)
+  //   // Get the asset type hierarchy
+  //   sqlQuery = `
+  //     WITH RECURSIVE ancestors AS (
+  //       SELECT asset_type_id, parent, asset_type_name FROM bedrock.asset_types
+  //       WHERE asset_type_id = $1
+  //       UNION
+  //         SELECT t.asset_type_id, t.parent, t.asset_type_name
+  //         FROM bedrock.asset_types t
+  //         INNER JOIN ancestors a ON a.parent = t.asset_type_id
+  //     ) SELECT * FROM ancestors;
+  //   `;
+  //   console.log(sqlQuery)
+  //   console.log(asset_type)
+  //   sqlResult = await client.query(sqlQuery, [asset_type]);
+  //   if (sqlResult.rowCount < 1) {
+  //     throw new Error(`Asset type ${asset_type} not found`);
+  //   }
+  //   sqlResult.rows.forEach((itm, i) => {
+  //     const comma = i > 0 ? ',' : '';
+  //     types = `${types}${comma} '${itm.asset_type_id}'`;
+  //   });
+  //   console.log(sqlResult)
+  //   console.log(types)
     // Now get custom fields associated with any of the types
     // Field is required if any type in the hierarchy requires it
     sqlQuery = `
@@ -52,11 +52,11 @@ async function getCustomFieldsInfo(client, asset_type) {
         select c.custom_field_id, c.custom_field_name, c.field_type, j.asset_type_id, j.required from bedrock.custom_fields c
         left outer join bedrock.asset_type_custom_fields j
         on c.custom_field_id = j.custom_field_id
-        where j.asset_type_id in (${types})
+        where j.asset_type_id = $1
       ) a
       group by custom_field_id, custom_field_name, field_type
     `;
-    sqlResult = await client.query(sqlQuery, []);
+    sqlResult = await client.query(sqlQuery, [asset_type]);
       console.log(sqlResult)
 
     sqlResult.rows.forEach((itm) => {

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -203,121 +203,6 @@ async function addAssetTypeCustomFields(client, idValue, body) {
   return body.custom_fields;
 }
 
-async function getAncestorCustomFieldsInfo(client, idValue) {
-  let sqlQuery;
-  let sqlResult;
-  let types = '';
-  const customFields = new Map();
-  try {
-    // Get the asset type hierarchy
-    sqlQuery = `
-      WITH RECURSIVE ancestors AS (
-        SELECT asset_type_id, parent, asset_type_name FROM bedrock.asset_types
-        WHERE asset_type_id = $1
-        UNION
-          SELECT t.asset_type_id, t.parent, t.asset_type_name
-          FROM bedrock.asset_types t
-          INNER JOIN ancestors a ON a.parent = t.asset_type_id
-      ) SELECT * FROM ancestors;
-    `;
-    sqlResult = await client.query(sqlQuery, [idValue]);
-    if (sqlResult.rowCount < 1) {
-      throw new Error(`Asset type ${idValue} not found`);
-    }
-  //   sqlResult.rows.forEach((itm, i) => {
-  //     const comma = i > 0 ? ',' : '';
-  //     if (itm.asset_type_id != idValue) {
-  //     types = `${types}${comma} '${itm.asset_type_id}'`;
-  // }});
-  let types = [];
-
-  sqlResult.rows.forEach((itm) => {
-    if (itm.asset_type_id != idValue) {
-      types.push(`'${itm.asset_type_id}'`);
-    }
-  });
-
-  types = types.join(', ');
-
-    // Now get custom fields associated with any of the types
-    // Field is required if any type in the hierarchy requires it
-    if (types) {
-      sqlQuery = `
-      select custom_field_id, custom_field_name, field_type, field_data, bool_or(required) as required
-      from (
-        select c.custom_field_id, c.custom_field_name, c.field_type, c.field_data, j.required from bedrock.custom_fields c
-        left outer join bedrock.asset_type_custom_fields j
-        on c.custom_field_id = j.custom_field_id
-        where j.asset_type_id in (${types})
-      ) a
-      group by custom_field_id, custom_field_name, field_type, field_data
-    `;
-    sqlResult = await client.query(sqlQuery, []);
-
-    sqlResult.rows.forEach((itm) => {
-      customFields.set(itm.custom_field_id, itm);
-    });
-    }
-
-  } catch (error) {
-    throw new Error(
-      `PG error getting asset type hierarchy for type ${idValue}: ${pgErrorCodes[error.code]}`,
-    );
-  }
-  return customFields;
-}
-
-function formatCustomFields(baseCustomFields, ancestorCustomFields) {
-
-  const combinedCustomFields = new Map();
-
-    // Process all entries from baseCustomFields
-    for (const [key, baseValue] of baseCustomFields) {
-        if (ancestorCustomFields.has(key)) {
-            // Property exists in both baseCustomFields and ancestorCustomFields
-            const ancestorValue = ancestorCustomFields.get(key);
-            combinedCustomFields.set(key, {
-                ...baseValue,
-                inherited: calculateInheritance(true, ancestorValue.required),
-                required: ancestorValue.required
-            });
-        } else {
-            // Property only exists in baseCustomFields
-            combinedCustomFields.set(key, {
-                ...baseValue,
-                inherited: calculateInheritance(false, baseValue.required)
-            });
-        }
-    }
-
-    // Add properties from ancestorCustomFields that are not in baseCustomFields
-    if (ancestorCustomFields) {
-      for (const [key] of ancestorCustomFields) {
-        const ancestorValue = ancestorCustomFields.get(key);
-        if (!baseCustomFields.has(key)) {
-          combinedCustomFields.set(key, {
-                ...ancestorValue,
-                inherited: calculateInheritance(true, ancestorValue.required)
-            });
-        }
-    }
-    }
-
-  return Object.fromEntries(combinedCustomFields);
-}
-
-function calculateInheritance(inherited, required) {
-  if (inherited) {
-    if (required) {
-      return 1
-    } else {
-      return 0
-    }
-  } else {
-    return -1
-  }
-}
-
 async function getBaseCustomFieldsInfo(client, idField, idValue, name, tableName) {
   let customFields = new Map();
     const sql = `
@@ -370,8 +255,6 @@ export {
   deleteInfo,
   generateId,
   addAssetTypeCustomFields,
-  formatCustomFields,
-  getAncestorCustomFieldsInfo,
   getBaseCustomFieldsInfo,
   checkBeforeDelete,
 };

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -237,7 +237,6 @@ async function checkBeforeDelete(client, name, tableName, idField, idValue, conn
   }
 
   if (res.rowCount !== 0) {
-    console.log(res);
     res.rows.forEach((element) => list.push(element[connectedDataIdField]))
     throw new Error(`${capitalizeFirstLetter(name)} ${idValue} is still connected to one or more ${connectedData} (Ids: ${list.join(', ')}). You must delete these relationships from ${tableName} before deleting this ${name}.`)
   }


### PR DESCRIPTION
TLDR: Basically all the things we talked about tuesday.

Owners, run groups, asset_types, and assets checks that nothing depends/is connected to them before deletion. Helpful error message thrown.

Tags now deletes from linking table.

Custom_fields cannot be deleted, but the relationships between them and asset_types can be deleted (and corresponding message added). 

Inheritance removed (WOO).

Assets can have data added for any custom_fields, and an error is thrown if they are missing required info when added. GET /asset/{id} returns custom_values info for all related data in the custom_values table and for any custom_fields related to the asset's asset_type (even when they have no entry in custom_values table). 

I need to fix one little thing in POST /asset, but I'm going to ping one or both of you tomorrow with another quick question before doing so.
