### PR TITLE
email attachment when there are errors

### DIFF
--- a/src/etl/lambdas/etl_email_results/handler.js
+++ b/src/etl/lambdas/etl_email_results/handler.js
@@ -3,7 +3,7 @@ import sendEmails from './sendEmails.js';
 
 export async function lambda_handler(event) {
   try {
-    await sendEmails(event);
+    sendEmails(event);
     return {
       statusCode: 200
     };

--- a/src/etl/lambdas/etl_email_results/localtest.json
+++ b/src/etl/lambdas/etl_email_results/localtest.json
@@ -4,7 +4,72 @@
         "fakey_mcfakesterson.mun"
     ],
     "skipped": [],
-    "failure": [],
+    "failure": [
+      {
+        "name": "testdata_witherror.bed",
+        "job": {
+          "name": "testdata_witherror.bed",
+          "depends": [
+            "testdatafrom.bed"
+          ],
+          "etl_tasks": [
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "testdatafrom.bed",
+                "tablename": "fromtable",
+                "connection": "pubrecdb1/bedrock/bedrock_user",
+                "schemaname": "testdata",
+                "connection_id": "50ffafcd5055f2fbb9c0"
+              },
+              "target_location": {
+                "asset": "testdata_witherror.bed",
+                "tablename": "totable",
+                "connection": "pubrecdb1/bedrock/bedrock_user",
+                "schemaname": "testdata",
+                "connection_id": "50ffafcd5055f2fbb9c0"
+              }
+            }
+          ]
+        },
+        "result": {
+          "name": "testdata_witherror.bed",
+          "depends": [
+            "testdatafrom.bed"
+          ],
+          "etl_tasks": [
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "testdatafrom.bed",
+                "tablename": "fromtable",
+                "connection": "pubrecdb1/bedrock/bedrock_user",
+                "schemaname": "testdata",
+                "connection_id": "50ffafcd5055f2fbb9c0"
+              },
+              "target_location": {
+                "asset": "testdata_witherror.bed",
+                "tablename": "totable",
+                "connection": "pubrecdb1/bedrock/bedrock_user",
+                "schemaname": "testdata",
+                "connection_id": "50ffafcd5055f2fbb9c0"
+              },
+              "result": {
+                "statusCode": 500,
+                "body": {
+                  "lambda_output": "Lambda crash: Runtime.UnhandledPromiseRejection{\"errorType\":\"Runtime.UnhandledPromiseRejection\",\"errorMessage\":\"error: permission denied for table totable\",\"trace\":[\"Runtime.UnhandledPromiseRejection: error: permission denied for table totable\",\"    at process.<anonymous> (file:///var/runtime/index.mjs:1276:17)\",\"    at process.emit (node:events:519:28)\",\"    at emit (node:internal/process/promises:150:20)\",\"    at processPromiseRejections (node:internal/process/promises:284:27)\",\"    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)\"]}"
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
     "results": null,
-    "RunSetIsGo": false
-}
+    "RunSetIsGo": false,
+    "TaskOutput": {
+      "statusCode": 200
+    }
+  }

--- a/src/etl/lambdas/etl_email_results/localtest2.json
+++ b/src/etl/lambdas/etl_email_results/localtest2.json
@@ -1,0 +1,13 @@
+{
+    "success": [
+        "fakey_mcfakesterson.s3",
+        "fakey_mcfakesterson.mun"
+    ],
+    "skipped": [],
+    "failure": [],
+    "results": null,
+    "RunSetIsGo": false,
+    "TaskOutput": {
+      "statusCode": 200
+    }
+  }

--- a/src/etl/lambdas/etl_email_results/makefile
+++ b/src/etl/lambdas/etl_email_results/makefile
@@ -31,7 +31,7 @@ apply: function.zip $(TF_TARGS) $(dirs)
 apply-y: function.zip $(TF_TARGS) $(dirs)
 destroy: $(TF_TARGS) $(dirs)
 
-node_modules: $(code_files)
+node_modules: ./package.json
 	npm install
 
 local: node_modules

--- a/src/etl/lambdas/etl_email_results/sendEmails.js
+++ b/src/etl/lambdas/etl_email_results/sendEmails.js
@@ -13,20 +13,21 @@ function sendEmails(results) {
     let emailRecip = [process.env.EMAIL_RECIPIENT];
     let emailSender = process.env.EMAIL_SENDER;
     let htmlEmail, emailSubject;
-      results.failure = results.failure.map(res => res.name);
-      results.failure.sort();
-      results.success.sort();
-      results.skipped.sort();
+    let failureMessages = results.failure.map(res => res.result);
+    results.failure = results.failure.map(res => res.name);
+    results.failure.sort();
+    results.success.sort();
+    results.skipped.sort();
 
-      emailSubject = "ETL Jobs Status: OK";
-      if (results.skipped.length > 0 || results.failure.length > 0) {
-        emailSubject = "ETL Jobs Status: Error";
-      }
+    emailSubject = "ETL Jobs Status: OK";
+    if (results.skipped.length > 0 || results.failure.length > 0) {
+      emailSubject = "ETL Jobs Status: Error";
+    }
 
-      let pugObj = {};
-      pugObj.results = results;
-      htmlEmail = compiledFunction(pugObj);
-      return ses_sendemail(emailRecip, emailSender, htmlEmail, emailSubject);
+    let pugObj = {};
+    pugObj.results = results;
+    htmlEmail = compiledFunction(pugObj);
+    return ses_sendemail(emailRecip, emailSender, htmlEmail, emailSubject, failureMessages);
   }else{
     console.log('No email sent');
   }

--- a/src/etl/lambdas/etl_email_results/ses_sendemail.js
+++ b/src/etl/lambdas/etl_email_results/ses_sendemail.js
@@ -1,43 +1,55 @@
-import { SESClient, SendEmailCommand } from "@aws-sdk/client-ses";
-const REGION = "us-east-1";
-const sesClient = new SESClient({ region: REGION });
+import { SESClient, SendRawEmailCommand } from "@aws-sdk/client-ses";
 
-async function ses_sendemail(emailAddrs, emailSender, htmlEmail, emailSubject) {
-  let params = {
-    Destination: {
-      CcAddresses: [],
-      ToAddresses: emailAddrs,
-    },
-    Message: { /* required */
-      Body: { /* required */
-        Html: {
-          Charset: "UTF-8",
-          Data: htmlEmail,
-        },
-        Text: {
-          Charset: "UTF-8",
-          Data: htmlEmail,
-        },
-      },
-      Subject: {
-        Charset: "UTF-8",
-        Data: emailSubject
-      },
-    },
+async function ses_sendemail(emailAddrs, emailSender, htmlEmail, emailSubject, failureMessages)  {
+
+  const sesClient = new SESClient({ region: "us-east-1" });
+
+  let attachmentPart = "";
+  if(failureMessages.length > 0){
+    let attachment = JSON.stringify(failureMessages,null,2);
+    attachmentPart = [
+      `--boundary`,
+      `Content-Type: application/json`,
+      `Content-Disposition: attachment; filename="error_messages.json"`,
+      ``,
+      `${attachment}`,
+      ``,
+      `--boundary--`
+    ].join("\n");
+  }
+
+  let rawMessage = [
+    `From: ${emailSender}`,
+    `To: ${emailAddrs.join(",")}`,
+    `Subject: ${emailSubject}`,
+    `Content-Type: multipart/mixed; boundary="boundary"`,
+    ``,
+    `--boundary`,
+    `Content-Type: text/html; charset=UTF-8`,
+    ``,
+    `${htmlEmail}`,
+    ``,
+    `${attachmentPart}`,
+    `--boundary--`
+  ].join("\n");
+
+  const rawEmail = {
     Source: emailSender,
-    ReplyToAddresses: [
-      emailSender,
-    ],
+    Destinations: emailAddrs,
+    RawMessage: {
+      Data: Buffer.from(
+        rawMessage
+      ),
+    },
   };
 
-  const sendEmailCommand = new SendEmailCommand(params);
-
   try {
-    return await sesClient.send(sendEmailCommand);
-  } catch (e) {
-    console.error("Failed to send email.", e);
-    return e;
+    const sendRawEmailCommand = new SendRawEmailCommand(rawEmail);
+    const response = await sesClient.send(sendRawEmailCommand);
+    console.log("Email sent successfully:", response.MessageId);
+  } catch (error) {
+    console.error("Error sending email:", error);
   }
-};
+}
 
 export default ses_sendemail;


### PR DESCRIPTION
The results email will include an attachment called error_messages.json when there are errors.

These look like this:

[
  {
    "name": "testdata_witherror.bed",
    "depends": [
      "testdatafrom.bed"
    ],
    "etl_tasks": [
      {
        "type": "table_copy",
        "active": true,
        "source_location": {
          "asset": "testdatafrom.bed",
          "tablename": "fromtable",
          "connection": "pubrecdb1/bedrock/bedrock_user",
          "schemaname": "testdata",
          "connection_id": "50ffafcd5055f2fbb9c0"
        },
        "target_location": {
          "asset": "testdata_witherror.bed",
          "tablename": "totable",
          "connection": "pubrecdb1/bedrock/bedrock_user",
          "schemaname": "testdata",
          "connection_id": "50ffafcd5055f2fbb9c0"
        },
        "result": {
          "statusCode": 500,
          "body": {
            "lambda_output": "Lambda crash: Runtime.UnhandledPromiseRejection{\"errorType\":\"Runtime.UnhandledPromiseRejection\",\"errorMessage\":\"error: permission denied for table totable\",\"trace\":[\"Runtime.UnhandledPromiseRejection: error: permission denied for table totable\",\"    at process.<anonymous> (file:///var/runtime/index.mjs:1276:17)\",\"    at process.emit (node:events:519:28)\",\"    at emit (node:internal/process/promises:150:20)\",\"    at processPromiseRejections (node:internal/process/promises:284:27)\",\"    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)\"]}"
          }
        }
      }
    ]
  }
]