### PR TITLE
PUT tasks requests now work when required properties set to false

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
@@ -69,8 +69,7 @@ async function addTasks(client, allFields, body) {
       if (obj[key] || obj[key] === 0 || obj[key] === false) {
         if (key === 'source' || key === 'target') {
           valuesFromBody.push(JSON.stringify(obj[key]));
-          // valuesFromBody.push(obj[key]);
-        } else  {
+        } else {
           valuesFromBody.push(obj[key]);
           };
       } else if (key === 'task_id') {

--- a/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
@@ -66,7 +66,7 @@ async function addTasks(client, allFields, body) {
   for (const obj of body.items) {
     const valuesFromBody = [];
     allFields.forEach((key) => {
-      if (obj[key] || obj[key] === 0) {
+      if (obj[key] || obj[key] === 0 || obj[key] === false) {
         if (key === 'source' || key === 'target') {
           valuesFromBody.push(JSON.stringify(obj[key]));
           // valuesFromBody.push(obj[key]);
@@ -81,6 +81,8 @@ async function addTasks(client, allFields, body) {
         valuesFromBody.push(null);
       }
     });
+
+    console.log(valuesFromBody)
 
     try {
       await client

--- a/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
@@ -82,8 +82,6 @@ async function addTasks(client, allFields, body) {
       }
     });
 
-    console.log(valuesFromBody)
-
     try {
       await client
         .query(`INSERT INTO bedrock.tasks ${fieldsString} VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`, valuesFromBody);


### PR DESCRIPTION
The way I was previously evaluating property values in updateTasks meant that anything set to false would be added as a null value instead, and the db would often throw an error. Fixed that with some strict equals.