### PR TITLE
fixing updateTasks to update or insert run_group info

### DIFF
--- a/docs/NewDBExperiment/createNewBedrockDB.sql
+++ b/docs/NewDBExperiment/createNewBedrockDB.sql
@@ -170,7 +170,8 @@ CREATE TABLE bedrock.etl (
 	asset_id text NOT NULL,
 	run_group_id text NOT NULL,
 	active bool NOT NULL,
-	CONSTRAINT etl_key UNIQUE (asset_id, run_group_id)
+	CONSTRAINT etl_key UNIQUE (asset_id, run_group_id),
+	CONSTRAINT etl_unique UNIQUE (asset_id)
 );
 --
 ALTER TABLE bedrock.etl OWNER TO bedrock_user;

--- a/src/db/bedrock-db/createNewBedrockDB.sql
+++ b/src/db/bedrock-db/createNewBedrockDB.sql
@@ -170,7 +170,8 @@ CREATE TABLE bedrock.etl (
 	asset_id text NOT NULL,
 	run_group_id text NOT NULL,
 	active bool NOT NULL,
-	CONSTRAINT etl_key UNIQUE (asset_id, run_group_id)
+	CONSTRAINT etl_key UNIQUE (asset_id, run_group_id),
+	CONSTRAINT etl_unique UNIQUE (asset_id)
 );
 --
 ALTER TABLE bedrock.etl OWNER TO bedrock_user;


### PR DESCRIPTION
Previously updateTasks.js (PUT /assets/{asset_id}/tasks) assumed an asset was already in the etl table. Now the code uses an "upsert" (INSERT + ON CONFLICT) query to either add or update the info, depending on if the asset is already present.

To use this query, the table must have a unique constraint on the id column being used, so I added a new constraint to the file that generates the database, and to the dev database that we're using now. (aka figured out a sql error WOO)