### PR TITLE
PUT /tasks and DEL /asset small fixes

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -25,7 +25,7 @@ async function deleteAsset(
 ) {
   let client;
   const shouldExist = true;
-  const tableNames = ['bedrock.assets', 'bedrock.custom_values', 'bedrock.asset_tags', 'bedrock.dependencies', 'bedrock.tasks'];
+  const tableNames = ['bedrock.assets', 'bedrock.custom_values', 'bedrock.asset_tags', 'bedrock.dependencies', 'bedrock.tasks', 'bedrock.etl'];
   const dependencyTableName = 'bedrock.dependencies';
   const connectedData = 'dependent assets';
   const connectedDataIdField = 'dependent_asset_id';


### PR DESCRIPTION
UpdateTasks now defaults to using the asset_id from the url, and checks that an asset exists before adding tasks. Deleting an asset now deletes it in the etl table too.