### PR TITLE
option to not send email for etl task

### DIFF
--- a/src/etl/lambdas/create_etl_run_map/localtest.json
+++ b/src/etl/lambdas/create_etl_run_map/localtest.json
@@ -1,4 +1,4 @@
 { 
-  "one_asset": "ad_info.lib", 
+  "one_asset": "testdatato.bed", 
   "debug": true
 }

--- a/src/etl/lambdas/etl_email_results/handler.js
+++ b/src/etl/lambdas/etl_email_results/handler.js
@@ -3,9 +3,10 @@ import sendEmails from './sendEmails.js';
 
 export async function lambda_handler(event) {
   try {
-    sendEmails(event);
+    let msg = await sendEmails(event);
     return {
-      statusCode: 200
+      statusCode: 200,
+      body: msg
     };
   } catch (error) {
     console.error(error);

--- a/src/etl/lambdas/etl_email_results/localtest.json
+++ b/src/etl/lambdas/etl_email_results/localtest.json
@@ -3,6 +3,7 @@
         "fakey_mcfakesterson.s3",
         "fakey_mcfakesterson.mun"
     ],
+    "noemail": [],
     "skipped": [],
     "failure": [
       {

--- a/src/etl/lambdas/etl_email_results/sendEmails.js
+++ b/src/etl/lambdas/etl_email_results/sendEmails.js
@@ -7,7 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url)); // current directory
 
 const compiledFunction = compileFile(join(__dirname, '/email.pug'));
 
-function sendEmails(results) {
+async function sendEmails(results) {
   const totalResults = results?.failure?.length + results?.success?.length + results?.skipped?.length;
   if (totalResults > 0) {
     let emailRecip = [process.env.EMAIL_RECIPIENT];
@@ -17,8 +17,8 @@ function sendEmails(results) {
     results.failure = results.failure.map(res => res.name);
     results.failure.sort();
     results.success.sort();
+    results.noemail.sort();
     results.skipped.sort();
-
     emailSubject = "ETL Jobs Status: OK";
     if (results.skipped.length > 0 || results.failure.length > 0) {
       emailSubject = "ETL Jobs Status: Error";
@@ -27,9 +27,10 @@ function sendEmails(results) {
     let pugObj = {};
     pugObj.results = results;
     htmlEmail = compiledFunction(pugObj);
-    return ses_sendemail(emailRecip, emailSender, htmlEmail, emailSubject, failureMessages);
+    return await ses_sendemail(emailRecip, emailSender, htmlEmail, emailSubject, failureMessages);
   }else{
     console.log('No email sent');
+    return 'No email sent';
   }
 }
 

--- a/src/etl/lambdas/etl_email_results/ses_sendemail.js
+++ b/src/etl/lambdas/etl_email_results/ses_sendemail.js
@@ -47,8 +47,10 @@ async function ses_sendemail(emailAddrs, emailSender, htmlEmail, emailSubject, f
     const sendRawEmailCommand = new SendRawEmailCommand(rawEmail);
     const response = await sesClient.send(sendRawEmailCommand);
     console.log("Email sent successfully:", response.MessageId);
+    return "Email sent successfully:" + response.MessageId;
   } catch (error) {
     console.error("Error sending email:", error);
+    return error;
   }
 }
 

--- a/src/etl/lambdas/update_etl_run_map/local.py
+++ b/src/etl/lambdas/update_etl_run_map/local.py
@@ -13,4 +13,5 @@ f = open(filename)
 event = json.load(f)
 f.close()
 
-lambda_handler(event, context)
+json_object = json.dumps(lambda_handler(event, context), indent = 4) 
+# print(json_object) 

--- a/src/etl/lambdas/update_etl_run_map/localtest.json
+++ b/src/etl/lambdas/update_etl_run_map/localtest.json
@@ -3,28 +3,127 @@
     "runsets": [
       [
         {
-          "name": "equity_students_completed.goog",
-          "run_group": "d",
+          "name": "public_meeting_data.lib",
+          "run_group": "every15",
           "depends": [
-            "training_students.lib"
+            "public_meeting_data.goog"
+          ],
+          "etl_tasks": [
+            {
+              "type": "table_copy",
+              "active": true,
+              "email": "only_on_error",
+              "source_location": {
+                "asset": "public_meeting_data.goog",
+                "tab": "ActiveMeetings",
+                "range": "A2:W",
+                "filename": "public_meeting_data",
+                "connection": "bedrock-googlesheets",
+                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+              },
+              "target_location": {
+                "asset": "public_meeting_data.lib",
+                "tablename": "public_meeting_data",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              }
+            },
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "public_meeting_data_archive.goog",
+                "tab": "MeetingArchive",
+                "range": "A2:W",
+                "filename": "public_meeting_data",
+                "connection": "bedrock-googlesheets",
+                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+              },
+              "target_location": {
+                "asset": "public_meeting_data.lib",
+                "append": true,
+                "tablename": "public_meeting_data",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              }
+            }
+          ]
+        },
+        {
+          "name": "public_meeting_data_categories.lib",
+          "run_group": "every15",
+          "depends": [
+            "public_meeting_data_categories.goog"
           ],
           "etl_tasks": [
             {
               "type": "table_copy",
               "active": true,
               "source_location": {
-                "asset": "equity_students_completed.lib",
-                "tablename": "equity_students_completed",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "aux"
+                "asset": "public_meeting_data_categories.goog",
+                "tab": "CategoryValues",
+                "range": "A2:E",
+                "filename": "public_meeting_data_categories",
+                "connection": "bedrock-googlesheets",
+                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
               },
               "target_location": {
-                "asset": "equity_students_completed.goog",
-                "tab": "Sheet1",
-                "range": "A2:Z",
-                "filename": "equity_students_completed",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "1xGD2jVSveuYjDLRc6Z8dlwGIA78LKJKxu0ck0Y7easg"
+                "asset": "public_meeting_data_categories.lib",
+                "tablename": "public_meeting_data_categories",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              }
+            }
+          ]
+        }
+      ],
+      [
+        {
+          "name": "public_meeting_data.pub",
+          "run_group": "every15",
+          "depends": [
+            "public_meeting_data.lib"
+          ],
+          "etl_tasks": [
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "public_meeting_data.lib",
+                "tablename": "public_meeting_data",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              },
+              "target_location": {
+                "asset": "public_meeting_data.pub",
+                "tablename": "public_meeting_data",
+                "connection": "coa-publicdb1/coa_share/dbadmin",
+                "schemaname": "open"
+              }
+            }
+          ]
+        },
+        {
+          "name": "public_meeting_data_categories.pub",
+          "run_group": "every15",
+          "depends": [
+            "public_meeting_data_categories.lib"
+          ],
+          "etl_tasks": [
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "public_meeting_data_categories.lib",
+                "tablename": "public_meeting_data_categories",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              },
+              "target_location": {
+                "asset": "public_meeting_data_categories.pub",
+                "tablename": "public_meeting_data_categories",
+                "connection": "coa-publicdb1/coa_share/dbadmin",
+                "schemaname": "open"
               }
             }
           ]
@@ -33,39 +132,166 @@
     ],
     "RunSetIsGo": true,
     "success": [],
+    "noemail": [],
     "skipped": [],
     "failure": [],
     "results": [
       {
         "JobIsGo": false,
         "ETLJob": {
-          "name": "equity_students_completed.goog",
-          "run_group": "d",
+          "name": "public_meeting_data.lib",
+          "run_group": "every15",
           "depends": [
-            "training_students.lib"
+            "public_meeting_data.goog"
           ],
           "etl_tasks": [
             {
               "type": "table_copy",
               "active": true,
               "source_location": {
-                "asset": "equity_students_completed.lib",
-                "tablename": "equity_students_completed",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "aux"
+                "asset": "public_meeting_data.goog",
+                "tab": "ActiveMeetings",
+                "range": "A2:W",
+                "filename": "public_meeting_data",
+                "connection": "bedrock-googlesheets",
+                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
               },
               "target_location": {
-                "asset": "equity_students_completed.goog",
-                "tab": "Sheet1",
-                "range": "A2:Z",
-                "filename": "equity_students_completed",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "1xGD2jVSveuYjDLRc6Z8dlwGIA78LKJKxu0ck0Y7easg"
+                "asset": "public_meeting_data.lib",
+                "tablename": "public_meeting_data",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
               },
               "result": {
                 "statusCode": 200,
                 "body": {
-                  "lambda_output": "Google Sheet copied 1xGD2jVSveuYjDLRc6Z8dlwGIA78LKJKxu0ck0Y7easg"
+                  "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
+                }
+              }
+            },
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "public_meeting_data_archive.goog",
+                "tab": "MeetingArchive",
+                "range": "A2:W",
+                "filename": "public_meeting_data",
+                "connection": "bedrock-googlesheets",
+                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+              },
+              "target_location": {
+                "asset": "public_meeting_data.lib",
+                "append": true,
+                "tablename": "public_meeting_data",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              },
+              "result": {
+                "statusCode": 200,
+                "body": {
+                  "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
+                }
+              }
+            }
+          ]
+        },
+        "TaskIndex": 1,
+        "JobType": "table_copy",
+        "results": {
+          "JobIsGo": false,
+          "ETLJob": {
+            "name": "public_meeting_data.lib",
+            "run_group": "every15",
+            "depends": [
+              "public_meeting_data.goog"
+            ],
+            "etl_tasks": [
+              {
+                "type": "table_copy",
+                "active": true,
+                "source_location": {
+                  "asset": "public_meeting_data.goog",
+                  "tab": "ActiveMeetings",
+                  "range": "A2:W",
+                  "filename": "public_meeting_data",
+                  "connection": "bedrock-googlesheets",
+                  "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+                },
+                "target_location": {
+                  "asset": "public_meeting_data.lib",
+                  "tablename": "public_meeting_data",
+                  "connection": "pubrecdb1/mdastore1/dbadmin",
+                  "schemaname": "internal"
+                },
+                "result": {
+                  "statusCode": 200,
+                  "body": {
+                    "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
+                  }
+                }
+              },
+              {
+                "type": "table_copy",
+                "active": true,
+                "source_location": {
+                  "asset": "public_meeting_data_archive.goog",
+                  "tab": "MeetingArchive",
+                  "range": "A2:W",
+                  "filename": "public_meeting_data",
+                  "connection": "bedrock-googlesheets",
+                  "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+                },
+                "target_location": {
+                  "asset": "public_meeting_data.lib",
+                  "append": true,
+                  "tablename": "public_meeting_data",
+                  "connection": "pubrecdb1/mdastore1/dbadmin",
+                  "schemaname": "internal"
+                },
+                "result": {
+                  "statusCode": 200,
+                  "body": {
+                    "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
+                  }
+                }
+              }
+            ]
+          },
+          "TaskIndex": 1,
+          "JobType": "table_copy"
+        }
+      },
+      {
+        "JobIsGo": false,
+        "ETLJob": {
+          "name": "public_meeting_data_categories.lib",
+          "run_group": "every15",
+          "depends": [
+            "public_meeting_data_categories.goog"
+          ],
+          "etl_tasks": [
+            {
+              "type": "table_copy",
+              "active": true,
+              "source_location": {
+                "asset": "public_meeting_data_categories.goog",
+                "tab": "CategoryValues",
+                "range": "A2:E",
+                "filename": "public_meeting_data_categories",
+                "connection": "bedrock-googlesheets",
+                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+              },
+              "target_location": {
+                "asset": "public_meeting_data_categories.lib",
+                "tablename": "public_meeting_data_categories",
+                "connection": "pubrecdb1/mdastore1/dbadmin",
+                "schemaname": "internal"
+              },
+              "result": {
+                "statusCode": 200,
+                "body": {
+                  "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data_categories"
                 }
               }
             }
@@ -76,33 +302,33 @@
         "results": {
           "JobIsGo": false,
           "ETLJob": {
-            "name": "equity_students_completed.goog",
-            "run_group": "d",
+            "name": "public_meeting_data_categories.lib",
+            "run_group": "every15",
             "depends": [
-              "training_students.lib"
+              "public_meeting_data_categories.goog"
             ],
             "etl_tasks": [
               {
                 "type": "table_copy",
                 "active": true,
                 "source_location": {
-                  "asset": "equity_students_completed.lib",
-                  "tablename": "equity_students_completed",
-                  "connection": "pubrecdb1/mdastore1/dbadmin",
-                  "schemaname": "aux"
+                  "asset": "public_meeting_data_categories.goog",
+                  "tab": "CategoryValues",
+                  "range": "A2:E",
+                  "filename": "public_meeting_data_categories",
+                  "connection": "bedrock-googlesheets",
+                  "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
                 },
                 "target_location": {
-                  "asset": "equity_students_completed.goog",
-                  "tab": "Sheet1",
-                  "range": "A2:Z",
-                  "filename": "equity_students_completed",
-                  "connection": "bedrock-googlesheets",
-                  "spreadsheetid": "1xGD2jVSveuYjDLRc6Z8dlwGIA78LKJKxu0ck0Y7easg"
+                  "asset": "public_meeting_data_categories.lib",
+                  "tablename": "public_meeting_data_categories",
+                  "connection": "pubrecdb1/mdastore1/dbadmin",
+                  "schemaname": "internal"
                 },
                 "result": {
                   "statusCode": 200,
                   "body": {
-                    "lambda_output": "Google Sheet copied 1xGD2jVSveuYjDLRc6Z8dlwGIA78LKJKxu0ck0Y7easg"
+                    "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data_categories"
                   }
                 }
               }

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -1,9 +1,8 @@
+# Deploy settings.
 INSTANCE = <UNIQUE INSTANCE STRING LIKE ej-test-0: lowercase alphanumeric characters and hyphens only>
 region = "us-east-1"
 statebucket = "avl-tfstate-store"
 account = 518970837364
-EMAIL_SENDER = "asheville_fake@ashevillenc.gov"
-EMAIL_RECIPIENT = "dummy@ashevillenc.gov"
 build_mode = std # Set to sam to build using SAM
 
 # The next four variables provide information on the VPC, subnets and security
@@ -35,6 +34,10 @@ STATE_MACHINE_ARN = "arn:aws:xxx"
 
 # This is the directory (relative to the root of the project) where the data files are stored.
 data_directory='src/db/bedrock-db-data/data';
+
+# Email settings
+EMAIL_SENDER = "asheville_fake@ashevillenc.gov"
+EMAIL_RECIPIENT = "dummy@ashevillenc.gov"
 
 # Do not edit or delete the next line
 reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))


### PR DESCRIPTION
This is a new flag that is added to tasks that specify that if the job is successful, don't send an email.
This is added to the target json:

- {"email": "only_on_error"}

This is for jobs like "public_meeting_data.lib" that run every 15 minutes, but we don't want an email unless it fails.