### PR TITLE
Tasks and relations endspoints better handle errors/missing info

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getAllAssetRelations.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 import pgErrorCodes from '../pgErrorCodes.js';
+import { checkExistence } from '../utilities/utilities.js';
 
 const { Client } = pgpkg;
 
@@ -105,10 +106,13 @@ async function getAllAssetRelations(
   connection,
   idValue,
   tableName,
+  idField,
+  name
 ) {
   let client;
   let relations;
   let res;
+  const shouldExist = true;
   const response = {
     error: false,
     message: '',
@@ -133,6 +137,7 @@ async function getAllAssetRelations(
   }
 
   try {
+    await checkExistence(client, 'bedrock.assets', idField, idValue, name, shouldExist)
     res = await readAsset(client, idValue, tableName);
     if (res.rowCount === 0) {
       response.message = 'No assets found';
@@ -146,6 +151,7 @@ async function getAllAssetRelations(
   } catch (error) {
     response.error = true;
     response.message = error.message;
+    response.result = null;
     return response;
   } finally {
     await client.end();

--- a/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
@@ -135,6 +135,8 @@ async function handleAssets(event, pathElements, queryParams, verb, connection) 
           connection,
           idValue,
           tableName,
+          idField,
+          name
         );
       } else {
         response.message = `Unknown assets endpoint: [${pathElements.join()}]`;


### PR DESCRIPTION
GET Tasks and relations endpoints:

throw an error if the asset is not in the assets table.

Otherwise:

return no error, and correct shape of data, even if it's empty/null/missing. 

This allows us to distinguish when an assets doesn't have etl/relations data, vs when the asset doesn't exist.