### PR TITLE
etl_task_file_copy: if no file found in source, skip putting to destination

### DIFF
--- a/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
@@ -37,9 +37,10 @@ def get_ftp(location):
                 source_file = lf[0]["name"]
             else:
                 source_file = None
-
+        fileResult = { "fileFound": True, "fileName": source_file }
         if not source_file:
             print('No recent source file matching pattern found')
+            fileResult["fileFound"] = False
         else:
             sftp.get(location["path"] + source_file, file_to_get)
             print('Downloaded from FTP: ' + source_file)
@@ -47,6 +48,8 @@ def get_ftp(location):
         sftp.close() 
     except BaseException as err:
         raise Exception("Get FTP Error: " + str(err))
+
+    return fileResult
 
 def put_ftp(location):
     try:

--- a/src/etl/lambdas/etl_task_file_copy/copy_s3.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_s3.py
@@ -3,6 +3,7 @@ import boto3
 s3 = boto3.client('s3')
         
 def download_s3(location):
+    fileResult = { "fileFound": True, "fileName": location["filename"] }
     try:
         s3.download_file(
             location["connection_data"]["s3_bucket"], 
@@ -11,6 +12,8 @@ def download_s3(location):
         print("File retrieved from S3: " + location["filename"])
     except BaseException as err:
         raise Exception("Download S3 Error: " + str(err))
+    
+    return fileResult
 
 def upload_s3(location):
     try:

--- a/src/etl/lambdas/etl_task_file_copy/copy_win.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_win.py
@@ -1,6 +1,7 @@
 from smb.SMBConnection import SMBConnection
 
 def get_win(location):
+  fileResult = { "fileFound": True, "fileName": location["filename"] }
   try:
     connection_data = location["connection_data"]
     share_name = connection_data['share_name']
@@ -11,6 +12,7 @@ def get_win(location):
     file_attributes, filesize = conn.retrieveFile(share_name, file_path, file_obj)
   except BaseException as err:
     raise Exception("Get Windows file share Error: " + str(err))
+  return fileResult
 
 def put_win(location):
   try:

--- a/src/etl/lambdas/etl_task_file_copy/handler.py
+++ b/src/etl/lambdas/etl_task_file_copy/handler.py
@@ -90,6 +90,8 @@ def lambda_handler(event, context):
                 put_win(target_location)
             else:
                 raise Exception("Invalid file copy connection type " + target_location["connection_data"]["type"])
+        else:
+            print('No file found - skipping put')
             
         if os.path.exists(tempfile):
                 os.remove(tempfile)

--- a/src/etl/lambdas/etl_task_file_copy/handler.py
+++ b/src/etl/lambdas/etl_task_file_copy/handler.py
@@ -70,24 +70,26 @@ def lambda_handler(event, context):
                 loc["config"] = location["config"]
 
         source_location = locations[0]
+        fileResult = None # Form: { fileFound: Bool, fileName: String }
         if source_location["connection_data"]["type"] == "s3":
-            download_s3(source_location)
+           fileResult = download_s3(source_location)
         elif source_location["connection_data"]["type"] == "sftp":
-            get_ftp(source_location)
+           fileResult = get_ftp(source_location)
         elif source_location["connection_data"]["type"] == "win":
-            get_win(source_location)
+           fileResult = get_win(source_location)
         else:
             raise Exception("Invalid file copy connection type " + source_location["connection_data"]["type"])
         
         target_location = locations[1]
-        if target_location["connection_data"]["type"] == "s3":
-            upload_s3(target_location)
-        elif target_location["connection_data"]["type"] == "sftp":
-            put_ftp(target_location)
-        elif target_location["connection_data"]["type"] == "win":
-            put_win(target_location)
-        else:
-            raise Exception("Invalid file copy connection type " + target_location["connection_data"]["type"])
+        if (fileResult and fileResult["fileFound"]):
+            if target_location["connection_data"]["type"] == "s3":
+                upload_s3(target_location)
+            elif target_location["connection_data"]["type"] == "sftp":
+                put_ftp(target_location)
+            elif target_location["connection_data"]["type"] == "win":
+                put_win(target_location)
+            else:
+                raise Exception("Invalid file copy connection type " + target_location["connection_data"]["type"])
             
         if os.path.exists(tempfile):
                 os.remove(tempfile)


### PR DESCRIPTION
The state stopped delivering test files yesterday and so the s3 put started throwing an error because the ftp get didn't create the temp file. 

Since we're not treating it as an error when an ftp file doesn't exist (a normal case especially with pattern-matching), we need to skip the put rather than letting it have an error when the temp file isn't found.

The s3 and win routines for getting files should be updated to support pattern-matching and checking for the existence of a file. I suggest we do that as part of an update to the orchestration that allows the resulting filename to be passed between etl_tasks.
