### PR TITLE
Fixing POST asset_types to handle when there are no custom fields

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -55,7 +55,13 @@ async function addAssetType(
     await client.query('BEGIN');
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
     response.result = await addInfo(client, allFields, bodyWithID, tableName, name);
-    response.result.custom_fields = await addAssetTypeCustomFields(client, idValue, body);
+    if (body.custom_fields) {
+      if (body.custom_fields.length > 0) {
+        response.result.custom_fields = await addAssetTypeCustomFields(client, idValue, body);
+      }
+    } else {
+      response.result.custom_fields = [];
+    }
     await client.query('COMMIT');
     await client.end();
   } catch (error) {


### PR DESCRIPTION
Fixed POST.

The two if statements feel a little funky- I could combine them, but I wanted the code to still work when custom_fields = null, and null.length throws an error. So I split up the if statements to make sure that error wouldn't be thrown.