### PR TITLE
fixing POST and PUT to work when CFs are empty or null

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -55,10 +55,8 @@ async function addAssetType(
     await client.query('BEGIN');
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
     response.result = await addInfo(client, allFields, bodyWithID, tableName, name);
-    if (body.custom_fields) {
-      if (body.custom_fields.length > 0) {
+    if (body.custom_fields?.length > 0) {
         response.result.custom_fields = await addAssetTypeCustomFields(client, idValue, body);
-      }
     } else {
       response.result.custom_fields = [];
     }

--- a/src/api/lambdas/bedrock-api-backend/asset_types/updateAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/updateAssetType.js
@@ -44,9 +44,12 @@ async function updateAssetType(
     await client.query('BEGIN');
     response.result = await updateInfo(client, allFields, body, tableName, idField, idValue, name);
     await deleteInfo(client, tableNameCustomFields, 'asset_type_id', idValue, name);
-    await addAssetTypeCustomFields(client, idValue, body);
+    if (body.custom_fields?.length > 0) {
+      await addAssetTypeCustomFields(client, idValue, body);
+    } else {
+      response.result.custom_fields = [];
+    }
     await client.query('COMMIT');
-
     await client.end();
   } catch (error) {
     await client.query('ROLLBACK');


### PR DESCRIPTION
Fixed /asset_types throwing an error for PUT method too (and put in some optional chaining while I was at it).