### PR TITLE
Api key / http status codes

### DIFF
--- a/docs/deploy-notes.md
+++ b/docs/deploy-notes.md
@@ -36,8 +36,12 @@ make seed    #(Fill database with assets from Github)
 # in src/make_variables (without the port number)
 ```
 
+#### API Key
+before you can build the API, you will need to set up an API key. This is created in Secrets Manager, in a key/value secret that must be called "Bedrock_API_Key". This secret has one key called API_KEY. Use the same value in the front end.
+
 #### API and ETL
 The remaining infrastructure requires a database to be set in src/make_variables.
+
 It also requires the shared set of Lambda Layers in the `bedrock_common` directory. 
 To build them, perform:
 

--- a/src/api/lambdas/bedrock-api-backend/.gitignore
+++ b/src/api/lambdas/bedrock-api-backend/.gitignore
@@ -1,0 +1,1 @@
+localtest.json

--- a/src/api/lambdas/bedrock-api-backend/deploy/config.tf
+++ b/src/api/lambdas/bedrock-api-backend/deploy/config.tf
@@ -29,6 +29,7 @@ resource "aws_lambda_function" "bedrock-api-backend-$$INSTANCE$$" {
       variables = {
         BEDROCK_DB_HOST = $$BEDROCK_DB_HOST$$
         STATE_MACHINE_ARN = $$STATE_MACHINE_ARN$$
+        API_KEY = jsondecode(data.aws_secretsmanager_secret_version.current.secret_string)["API_KEY"]
       }
     }
 }

--- a/src/api/lambdas/bedrock-api-backend/deploy/datablocks.tf
+++ b/src/api/lambdas/bedrock-api-backend/deploy/datablocks.tf
@@ -24,3 +24,11 @@ data "terraform_remote_state" "bedrock_packages_$$INSTANCE$$" {
     region = "us-east-1"
   }
 }
+
+data "aws_secretsmanager_secret" "secrets" {
+ name = "Bedrock_API_Key"
+}
+
+data "aws_secretsmanager_secret_version" "current" {
+  secret_id = data.aws_secretsmanager_secret.secrets.id
+}

--- a/src/api/lambdas/bedrock-api-backend/handler.js
+++ b/src/api/lambdas/bedrock-api-backend/handler.js
@@ -16,6 +16,15 @@ import handleExecuteETL from './execute_etl/handleExecuteETL.js';
 
 // eslint-disable-next-line camelcase, import/prefer-default-export
 export async function lambda_handler(event) {
+  if(event.headers.authorization !== process.env.API_KEY) {
+    let result = {
+      error: true,
+      message: 'Not Authorized',
+      result: null,
+    };
+    return result;
+  }
+
   let result = {
     error: true,
     message: 'Unknown resource',

--- a/src/api/lambdas/bedrock-api-backend/local.js
+++ b/src/api/lambdas/bedrock-api-backend/local.js
@@ -5,7 +5,12 @@ const host = 'localhost';
 const port = 8000;
 
 const requestListener = async function (req, res) {
+  // Bypass API_KEY authorization
+  process.env.API_KEY = req.headers.authorization;
   let event = {
+    headers : {
+      authorization: req.headers.authorization
+    },
     requestContext: {
       http: {
         method: req.method,
@@ -13,6 +18,7 @@ const requestListener = async function (req, res) {
       }
     }
   };
+
   let ret = await lambda_handler(event);
   res.setHeader("Content-Type", "application/json");
   res.writeHead(200);

--- a/src/api/lambdas/bedrock-api-backend/local.js
+++ b/src/api/lambdas/bedrock-api-backend/local.js
@@ -1,12 +1,14 @@
 import { createServer } from "http";
 import { lambda_handler } from './handler.js';
+import localtest from './localtest.json' with { type: "json" };
 
 const host = 'localhost';
 const port = 8000;
 
 const requestListener = async function (req, res) {
-  // Bypass API_KEY authorization
-  process.env.API_KEY = req.headers.authorization;
+
+  process.env.API_KEY = localtest.API_KEY;
+
   let event = {
     headers : {
       authorization: req.headers.authorization
@@ -20,9 +22,11 @@ const requestListener = async function (req, res) {
   };
 
   let ret = await lambda_handler(event);
-  res.setHeader("Content-Type", "application/json");
-  res.writeHead(200);
-  res.end(JSON.stringify(ret));
+  for(const header in ret.headers) {
+    res.setHeader(header, ret.headers[header]);
+  }
+  res.writeHead(ret.statusCode);
+  res.end(ret.body);
 };
 
 const server = createServer(requestListener);

--- a/src/api/lambdas/bedrock-api-backend/localtest.json.sample
+++ b/src/api/lambdas/bedrock-api-backend/localtest.json.sample
@@ -1,0 +1,4 @@
+// Create a file localtest.json in the format below with your API key.
+{
+  "API_KEY": "YOUR_API_KEY"
+}

--- a/src/api/lambdas/bedrock-api-backend/makefile
+++ b/src/api/lambdas/bedrock-api-backend/makefile
@@ -35,7 +35,8 @@ node_modules: ./package.json
 
 local: node_modules
 	@export BEDROCK_DB_HOST=$(BEDROCK_DB_HOST);export BEDROCK_DB_USER=$(BEDROCK_DB_USER); \
-	export BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD);export BEDROCK_DB_NAME=$(BEDROCK_DB_NAME);npm start
+	export BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD);export BEDROCK_DB_NAME=$(BEDROCK_DB_NAME); \
+	export API_KEY=${API_KEY};npm start
 	
 clean:
 	rm -f *.instance

--- a/src/api/lambdas/bedrock-api-backend/package-lock.json
+++ b/src/api/lambdas/bedrock-api-backend/package-lock.json
@@ -300,53 +300,53 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.609.0.tgz",
-      "integrity": "sha512-+us5UQmuZu7Qd33l9xt2TZ2TAT4LWY7QfjSCUaaR8/LRNG6af1LvKfdxSC5iYU+jjb6Yrc1FITH/IoNxbjD6NQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.631.0.tgz",
+      "integrity": "sha512-r34Bbuerxr664/+P6iDrwoIAvHcGPvelD79gJ6PteUYEjCXVzhKtcnzuJSq0FGK7+OUnq9F+TzdUA0AtkKWpNw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
         "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "@smithy/util-utf8": "^3.0.0",
         "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
@@ -425,44 +425,44 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+      "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -473,45 +473,45 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+      "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -521,50 +521,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+      "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -575,16 +575,19 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
       "dependencies": {
-        "@smithy/core": "^2.2.4",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -592,9 +595,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -606,18 +609,18 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+      "version": "3.622.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+      "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -625,19 +628,19 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+      "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -645,24 +648,24 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+      "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-ini": "3.631.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -671,13 +674,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -686,15 +689,15 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+      "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
+        "@aws-sdk/client-sso": "3.631.0",
+        "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -703,9 +706,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -716,16 +719,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -747,12 +750,12 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -761,13 +764,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+      "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@aws-sdk/util-endpoints": "3.631.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -776,12 +779,12 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -792,13 +795,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -806,7 +809,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
@@ -822,13 +825,13 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+      "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -847,12 +850,12 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -868,15 +871,22 @@
         }
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-buffer-from": {
@@ -891,66 +901,98 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.609.0.tgz",
-      "integrity": "sha512-lh8NxL9qm8eSphEcsTGjNMArYRlga4yTZCr3d7UPCRFiV1oz3e0EIA5EnxSriYi9P5Houi5d9GSWtPOel2mAow==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.631.0.tgz",
+      "integrity": "sha512-VBZoG6oMMsL5zOvO8Wxxcpv4T/qmQiTv58C+7c4zaHsIM2lCzQsU042XwH/jenqPsse1FTM45HnanRDOLv99+w==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.609.0",
-        "@aws-sdk/middleware-expect-continue": "3.609.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.620.0",
+        "@aws-sdk/middleware-expect-continue": "3.620.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-location-constraint": "3.609.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-sdk-s3": "3.609.0",
-        "@aws-sdk/middleware-signing": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-s3": "3.629.0",
         "@aws-sdk/middleware-ssec": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/signature-v4-multi-region": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/signature-v4-multi-region": "3.629.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
         "@aws-sdk/xml-builder": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
         "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-blob-browser": "^3.1.2",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/hash-stream-node": "^3.1.2",
         "@smithy/invalid-dependency": "^3.0.3",
         "@smithy/md5-js": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "@smithy/util-utf8": "^3.0.0",
         "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
@@ -1029,44 +1071,44 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+      "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1077,45 +1119,45 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+      "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1125,50 +1167,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+      "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1179,16 +1221,19 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
       "dependencies": {
-        "@smithy/core": "^2.2.4",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1196,9 +1241,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -1210,18 +1255,18 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+      "version": "3.622.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+      "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1229,19 +1274,19 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+      "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1249,24 +1294,24 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+      "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-ini": "3.631.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1275,13 +1320,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1290,15 +1335,15 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+      "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
+        "@aws-sdk/client-sso": "3.631.0",
+        "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1307,9 +1352,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -1320,16 +1365,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1351,12 +1396,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1365,13 +1410,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+      "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@aws-sdk/util-endpoints": "3.631.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1380,12 +1425,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -1396,13 +1441,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1410,7 +1455,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
@@ -1426,13 +1471,13 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+      "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1451,12 +1496,12 @@
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1472,15 +1517,22 @@
         }
       }
     },
-    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from": {
@@ -1495,48 +1547,80 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.609.0.tgz",
-      "integrity": "sha512-1vDLUl0TuZx7TATsYkIaKj9etNzTpFVF95FpfFnJeyen397tYLot5sUNkcMCJvOLbdNVnJo1o5F8GNfU776EIQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.631.0.tgz",
+      "integrity": "sha512-wNLWR3nohNeEkF3IPAAstvJT0rGTJ8RCpB3naPbdhbRoFwMRgzlvjtpPvLN19jJlvrHtpujISZAKrm7j01i8Yg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1617,44 +1701,44 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+      "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1665,45 +1749,45 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+      "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1713,50 +1797,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+      "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -1767,16 +1851,19 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
       "dependencies": {
-        "@smithy/core": "^2.2.4",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1784,9 +1871,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -1798,18 +1885,18 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+      "version": "3.622.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+      "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1817,19 +1904,19 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+      "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1837,24 +1924,24 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+      "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-ini": "3.631.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1863,13 +1950,13 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1878,15 +1965,15 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+      "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
+        "@aws-sdk/client-sso": "3.631.0",
+        "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1895,9 +1982,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -1908,16 +1995,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1939,12 +2026,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1953,13 +2040,13 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+      "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@aws-sdk/util-endpoints": "3.631.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1968,12 +2055,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -1984,13 +2071,13 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -1998,7 +2085,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/types": {
@@ -2014,13 +2101,13 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+      "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2039,12 +2126,12 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2060,15 +2147,22 @@
         }
       }
     },
-    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-buffer-from": {
@@ -2083,48 +2177,80 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-secrets-manager/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-ses": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.609.0.tgz",
-      "integrity": "sha512-tfTfTl8IuKcOLFSlUA6XCSbzAVQ+MCdCl0Fme2Rd/GsKgB3Momyh4HcVHI09S5HaYTo/7P3ovJBOdv6JcKVDDw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.631.0.tgz",
+      "integrity": "sha512-vS3hsW4OURlOosBpg+K87HA4AF1j5sUbmSUQJ9QMGS7oc06p62Td3n+Ne1dQwuohKil5OcKHLGzkQ61fYq58vQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -2205,44 +2331,44 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+      "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -2253,45 +2379,45 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+      "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -2301,50 +2427,50 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+      "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -2355,16 +2481,19 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
       "dependencies": {
-        "@smithy/core": "^2.2.4",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2372,9 +2501,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+      "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -2386,18 +2515,18 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+      "version": "3.622.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+      "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2405,19 +2534,19 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+      "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2425,24 +2554,24 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+      "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
+        "@aws-sdk/credential-provider-env": "3.620.1",
+        "@aws-sdk/credential-provider-http": "3.622.0",
+        "@aws-sdk/credential-provider-ini": "3.631.0",
+        "@aws-sdk/credential-provider-process": "3.620.1",
+        "@aws-sdk/credential-provider-sso": "3.631.0",
+        "@aws-sdk/credential-provider-web-identity": "3.621.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2451,13 +2580,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+      "version": "3.620.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+      "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2466,15 +2595,15 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+      "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
+        "@aws-sdk/client-sso": "3.631.0",
+        "@aws-sdk/token-providers": "3.614.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2483,9 +2612,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+      "version": "3.621.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+      "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
@@ -2496,16 +2625,16 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
+        "@aws-sdk/client-sts": "^3.621.0"
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+      "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2527,12 +2656,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+      "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2541,13 +2670,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+      "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@aws-sdk/util-endpoints": "3.631.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2556,12 +2685,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+      "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
@@ -2572,13 +2701,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+      "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
+        "@smithy/shared-ini-file-loader": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2586,7 +2715,7 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
+        "@aws-sdk/client-sso-oidc": "^3.614.0"
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/types": {
@@ -2602,13 +2731,13 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+      "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-endpoints": "^2.0.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2627,12 +2756,12 @@
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+      "version": "3.614.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+      "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
+        "@smithy/node-config-provider": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -2648,15 +2777,22 @@
         }
       }
     },
-    "node_modules/@aws-sdk/client-ses/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+    "node_modules/@aws-sdk/client-ses/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ses/node_modules/@smithy/util-buffer-from": {
@@ -2669,6 +2805,38 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ses/node_modules/@smithy/util-buffer-from/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ses/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/client-sfn": {
@@ -3017,13 +3185,13 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.609.0.tgz",
-      "integrity": "sha512-572EZF6x9PtDfRbRAlBx1ZNpolA6Ol3kUmZZT6lStMTsgLiAss7lJlp35eAdPTUMIREcY9E2hEbI7imPS2506g==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.631.0.tgz",
+      "integrity": "sha512-B3sZoKqqoe2o8MLdOsUVdZzmbnjcQv+tbexbCOQxIDXBp+5QQAaYgkTRrxdqkmb73AUNw+mlfevyNdwgrx3PNg==",
       "dependencies": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -3033,18 +3201,18 @@
         "node": ">=16.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.609.0"
+        "@aws-sdk/client-s3": "^3.631.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.609.0.tgz",
-      "integrity": "sha512-QhHRfr4e7FqaMUAnOAFdQVOR3yDLw40i1IZPo+TeiKyev9LEyYEX2l6DbdaIwAztofOpAxfFNj/IJ0V/efzz/w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.620.0.tgz",
+      "integrity": "sha512-eGLL0W6L3HDb3OACyetZYOWpHJ+gLo0TehQKeQyy2G8vTYXqNTeqYhuI6up9HVjBzU9eQiULVQETmgQs7TFaRg==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
@@ -3066,12 +3234,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.609.0.tgz",
-      "integrity": "sha512-+zeg//mSer4JZRxOB/4mUOMUJyuYPwATnIC5moBB8P8Xe+mJaVRFy8qlCtzYNj2TycnlsBPzTK0j7P1yvDh97w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
+      "integrity": "sha512-QXeRFMLfyQ31nAHLbiTLtk0oHzG9QLMaof5jIfqcUwnOkO8YnQdeqzakrg1Alpy/VQ7aqzIi8qypkBe2KXZz0A==",
       "dependencies": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -3092,15 +3260,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.609.0.tgz",
-      "integrity": "sha512-TJ4WE+ehT+qcrhr7/yJCzmJJPmUoPPWIbCnFzqGxauH/dpVBCslmd1vZg3h2VnfRiaDkc6f68dqYVc29CaurhQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.620.0.tgz",
+      "integrity": "sha512-ftz+NW7qka2sVuwnnO1IzBku5ccP+s5qZGeRTPgrKB7OzRW85gthvIo1vQR2w+OwHFk7WJbbhhWwbCbktnP4UA==",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -3188,18 +3356,43 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.609.0.tgz",
-      "integrity": "sha512-kvwjL6OJFhAGWoYaIWR7HmILjiVk6xVj6QEU6qZMA7FtGgvlKi4pLfs8Of+hQqo+2TEhUoxG/5t6WqwB8uxjsw==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.629.0.tgz",
+      "integrity": "sha512-FRXLcnPWXBoq/T9mnGnrpqhrSKNSm22rqJ0L7P14KESmbGuwhF/7ELYYxXIpgnIpb/CIUVmIU5EE8lsW1VTe8A==",
       "dependencies": {
+        "@aws-sdk/core": "3.629.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+      "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
+      "dependencies": {
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/property-provider": "^3.1.3",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3218,33 +3411,43 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.609.0.tgz",
-      "integrity": "sha512-2w3dBLjQVKIajYzokO4hduq8/0hSMUYHHmIo1Kdl+MSY8uwRBt12bLL6pyreobTcRMxizvn2ph/CQ9I1ST/WGQ==",
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
       "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
         "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
       "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
+        "strnum": "^1.0.5"
       },
-      "engines": {
-        "node": ">=16.0.0"
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
@@ -3304,14 +3507,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.609.0.tgz",
-      "integrity": "sha512-FJs0BxVMyYOKNu7nzFI1kehfgWoYmdto5B8BSS29geUACF7jlOoeCfNZWVrnMjvAxVlSQ5O7Mr575932BnsycA==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.629.0.tgz",
+      "integrity": "sha512-GPX6dnmuLGDFp7CsGqGCzleEoNyr9ekgOzSBtcL5nKX++NruxO7f1QzJAbcYvz0gdKvz958UO0EKsGM6hnkTSg==",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.609.0",
+        "@aws-sdk/middleware-sdk-s3": "3.629.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -3325,6 +3528,24 @@
       "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+      "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/types": "^3.3.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3451,14 +3672,14 @@
       }
     },
     "node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-auth": {
@@ -3468,17 +3689,6 @@
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3502,17 +3712,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-client/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@azure/core-http-compat": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.1.2.tgz",
@@ -3521,17 +3720,6 @@
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-client": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-http-compat/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -3551,17 +3739,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-lro/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@azure/core-paging": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
@@ -3574,9 +3751,9 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.1.tgz",
-      "integrity": "sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha512-VxLk4AHLyqcHsfKe4MZ6IQ+D+ShuByy+RfStKfSjxJoL3WBWq17VNmrz8aT8etKzqc2nAeIyLxScjpzsS4fz8w==",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
@@ -3585,17 +3762,6 @@
         "@azure/logger": "^1.0.0",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure/core-rest-pipeline/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3614,9 +3780,9 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
-      "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.2.tgz",
+      "integrity": "sha512-l1Qrqhi4x1aekkV+OlcqsJa4AnAkj5p0JV8omgwjaV9OAbP41lvrMvs+CptfetKkeEaGRGSzby7sjPZEX7+kkQ==",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "tslib": "^2.6.2"
@@ -3625,31 +3791,20 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@azure/identity": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.4.2.tgz",
-      "integrity": "sha512-0q5DL4uyR0EZ4RXQKD8MadGH6zTIcloUoS/RVbCpNpej4pwte0xpqYxk8K97Py2RiuUvI7F4GXpoT4046VfufA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.4.1.tgz",
+      "integrity": "sha512-DwnG4cKFEM7S3T+9u05NstXU/HN0dk45kPOinUyNKsn5VWwpXd9sbPKEg6kgJzGbm1lMuhx9o31PVbCtM5sfBA==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
+        "@azure/core-client": "^1.9.2",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
+        "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
+        "@azure/msal-browser": "^3.14.0",
+        "@azure/msal-node": "^2.9.2",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
@@ -3657,7 +3812,18 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@azure/keyvault-keys": {
@@ -3681,10 +3847,21 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@azure/keyvault-keys/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@azure/logger": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.2.tgz",
-      "integrity": "sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3693,30 +3870,30 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.18.0.tgz",
-      "integrity": "sha512-jvK5bDUWbpOaJt2Io/rjcaOVcUzkqkrCme/WntdV1SMUc67AiTcEdKuY6G/nMQ7N5Cfsk9SfpugflQwDku53yg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.21.0.tgz",
+      "integrity": "sha512-BAwcFsVvOrYzKuUZHhFuvRykUmQGq6lDxst2qGnjxnpNZc3d/tnVPcmhgvUdeKl28VSE0ltgBzT3HkdpDtz9rg==",
       "dependencies": {
-        "@azure/msal-common": "14.13.0"
+        "@azure/msal-common": "14.14.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
-      "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA==",
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.14.1.tgz",
+      "integrity": "sha512-2Q3tqNz/PZLfSr8BvcHZVpRRfSn4MjGSqjj9J+HlBsmbf1Uu4P0WeXnemjTJwwx9KrmplsrN3UkZ/LPOR720rw==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
-      "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.13.0.tgz",
+      "integrity": "sha512-DhP97ycs7qlCVzzzWGzJiwAFyFj5okno74E4FUZ61oCLfKh4IxA1kxirqzrWuYZWpBe9HVPL6GA4NvmlEOBN5Q==",
       "dependencies": {
-        "@azure/msal-common": "14.13.0",
+        "@azure/msal-common": "14.14.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -3733,9 +3910,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3749,9 +3926,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
+      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "dependencies": {
+        "@babel/types": "^7.25.2"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -3760,11 +3940,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
+      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       },
@@ -3946,15 +4126,15 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.6.tgz",
-      "integrity": "sha512-tBbVIv/ui7/lLTKayYJJvi8JLVL2SwOQTbNFEOrvzSE3ktByvsa1erwBOnAMo8N5Vu30g7lN4lLStrU75oDGuw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.2.tgz",
+      "integrity": "sha512-in5wwt6chDBcUv1Lw1+QzZxN9fBffi+qOixfb65yK4sDuKG7zAUO9HAFqmVzsZM3N+3tTyvZjtnDXePpvp007Q==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
@@ -3964,9 +4144,9 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
-      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
@@ -3990,11 +4170,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.4.tgz",
-      "integrity": "sha512-Eo4anLZX6ltGJTZ5yJMc80gZPYYwBn44g0h7oFq6et+TYr5dUsTpIcDbz2evsOKIZhZ7zBoFWHtBXQ4QQeb5xA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
+      "integrity": "sha512-2hM54UWQUOrki4BtsUI1WzmD13/SeaqT/AB3EUJKbcver/WgKNaiJ5y5F5XXuVe6UekffVzuUDrBZVAA3AWRpQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.4",
+        "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4015,11 +4195,11 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.4.tgz",
-      "integrity": "sha512-mjlG0OzGAYuUpdUpflfb9zyLrBGgmQmrobNT8b42ZTsGv/J03+t24uhhtVEKG/b2jFtPIHF74Bq+VUtbzEKOKg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
+      "integrity": "sha512-+upXvnHNyZP095s11jF5dhGw/Ihzqwl5G+/KtMnoQOpdfC3B5HYCcDVG9EmgkhJMXJlM64PyN5gjJl0uXFQehQ==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^3.0.4",
+        "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4028,9 +4208,9 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.4.tgz",
-      "integrity": "sha512-Od9dv8zh3PgOD7Vj4T3HSuox16n0VG8jJIM2gvKASL6aCtcS8CfHZDWe1Ik3ZXW6xBouU+45Q5wgoliWDZiJ0A==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.5.tgz",
+      "integrity": "sha512-5u/nXbyoh1s4QxrvNre9V6vfyoLWuiVvvd5TlZjGThIikc3G+uNiG9uOTCWweSRjv1asdDIWK7nOmN7le4RYHQ==",
       "dependencies": {
         "@smithy/eventstream-codec": "^3.1.2",
         "@smithy/types": "^3.3.0",
@@ -4041,11 +4221,11 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-      "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
@@ -4121,11 +4301,11 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
-      "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "dependencies": {
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4134,9 +4314,9 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "dependencies": {
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
@@ -4151,14 +4331,14 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.9.tgz",
-      "integrity": "sha512-Mrv9omExU1gA7Y0VEJG2LieGfPYtwwcEiOnVGZ54a37NEMr66TJ0glFslOJFuKWG6izg5DpKIUmDV9rRxjm47Q==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.14.tgz",
+      "integrity": "sha512-7ZaWZJOjUxa5hgmuMspyt8v/zVsh0GXYuF7OvCmdcbVa/xbnKQoYC+uYKunAqRGTkxjOyuOCw9rmFUFOqqC0eQ==",
       "dependencies": {
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -4208,12 +4388,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.2.tgz",
-      "integrity": "sha512-Td3rUNI7qqtoSLTsJBtsyfoG4cF/XMFmJr6Z2dX8QNzIi6tIW6YmuyFml8mJ2cNpyWNqITKbROMOFrvQjmsOvw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "dependencies": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -4235,9 +4415,9 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
-      "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "dependencies": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -4312,15 +4492,15 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.7.tgz",
-      "integrity": "sha512-nZbJZB0XI3YnaFBWGDBr7kjaew6O0oNYNmopyIz6gKZEbxzrtH7rwvU1GcVxcSFoOwWecLJEe79fxEMljHopFQ==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.12.tgz",
+      "integrity": "sha512-wtm8JtsycthkHy1YA4zjIh2thJgIQ9vGkoR639DBx5lLlLNU0v4GARpQZkr2WjXue74nZ7MiTSWfVrLkyD8RkA==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.6",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4404,12 +4584,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.9.tgz",
-      "integrity": "sha512-WKPcElz92MAQG09miBdb0GxEH/MwD5GfE8g07WokITq5g6J1ROQfYCKC1wNnkqAGfrSywT7L0rdvvqlBplqiyA==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.14.tgz",
+      "integrity": "sha512-0iwTgKKmAIf+vFLV8fji21Jb2px11ktKVxbX6LIDPAUJyWQqGqBVfwba7xwa1f2FZUoolYQgLvxQEpJycXuQ5w==",
       "dependencies": {
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -4419,15 +4599,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.9.tgz",
-      "integrity": "sha512-dQLrUqFxqpf0GvEKEuFdgXcdZwz6oFm752h4d6C7lQz+RLddf761L2r7dSwGWzESMMB3wKj0jL+skRhEGlecjw==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.14.tgz",
+      "integrity": "sha512-e9uQarJKfXApkTMMruIdxHprhcXivH1flYCe8JRDTzkkLx8dA3V5J8GZlST9yfDiRWkJpZJlUXGN9Rc9Ade3OQ==",
       "dependencies": {
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -4485,12 +4665,12 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.6.tgz",
-      "integrity": "sha512-w9i//7egejAIvplX821rPWWgaiY1dxsQUw0hXX7qwa/uZ9U3zplqTQ871jWadkcVB9gFDhkPWYVZf4yfFbZ0xA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.1",
-        "@smithy/node-http-handler": "^3.1.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
@@ -4550,17 +4730,17 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.18.2"
       }
     },
     "node_modules/@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.15.tgz",
+      "integrity": "sha512-oAZ3kw+kJFkEqyh7xORZOku1YAKvsFTogRY8kVl4vHpEKiDkfnSA/My8haRE7fvmix5Zyy+1pwzOi7yycGLBJw==",
       "dependencies": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -4677,6 +4857,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -4747,6 +4928,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -4778,6 +4960,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -4849,7 +5032,7 @@
         "@aws-sdk/client-sfn": "^3.592.0",
         "@aws-sdk/lib-storage": "^3.431.0",
         "aws-cron-parser": "^1.1.12",
-        "mssql": "^10.0.2",
+        "mssql": "^11.0.1",
         "nanoid": "^5.0.7",
         "pg": "^8.11.3",
         "pug": "^3.0.2",
@@ -4869,9 +5052,9 @@
       }
     },
     "node_modules/bl": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.13.tgz",
-      "integrity": "sha512-tMncAcpsyjZgAVbVFupVIaB2xud13xxT59fdHkuszY2jdZkqIWfpQdmII1fOe3kOGAz0mNLTIHEm+KxpYsQKKg==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.14.tgz",
+      "integrity": "sha512-TJfbvGdL7KFGxTsEbsED7avqpFdY56q9IW0/aiytyheJzxST/+Io6cx/4Qx0K2/u0BPRDs65mjaQzYvMZeNocQ==",
       "dependencies": {
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
@@ -5110,6 +5293,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -5126,6 +5310,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -5142,6 +5327,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -5204,6 +5390,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -5245,6 +5432,7 @@
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -5300,27 +5488,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-aggregate-error": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
-      "integrity": "sha512-KkzhUUuD2CUMqEc8JEqsXEMDHzDPE8RCjZeUBitsnB1eNcAJWQPiciKsMXe3Yytj4Flw1XLl46Qcf9OxvZha7A==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.2",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -5344,6 +5511,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -5355,6 +5523,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -5377,6 +5546,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -5781,6 +5951,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
       }
@@ -5817,6 +5988,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -5834,6 +6006,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5860,6 +6033,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -5923,6 +6097,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -5965,6 +6140,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6149,6 +6325,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -6162,6 +6339,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -6177,6 +6355,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -6200,6 +6379,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -6215,6 +6395,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6237,6 +6418,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
       "dependencies": {
         "is-typed-array": "^1.1.13"
       },
@@ -6251,6 +6433,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6320,6 +6503,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6340,6 +6524,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6383,6 +6568,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7"
       },
@@ -6397,6 +6583,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -6411,6 +6598,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -6425,6 +6613,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dev": true,
       "dependencies": {
         "which-typed-array": "^1.1.14"
       },
@@ -6439,6 +6628,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
       },
@@ -6460,7 +6650,8 @@
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6499,11 +6690,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -6570,9 +6756,9 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6704,22 +6890,22 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mssql": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/mssql/-/mssql-10.0.4.tgz",
-      "integrity": "sha512-MhX5IcJ75/q+dUiOe+1ajpqjEe96ZKqMchYYPUIDU+Btqhwt4gbFeZhcGUZaRCEMV9uF+G8kLvaNSFaEzL9OXQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-11.0.1.tgz",
+      "integrity": "sha512-KlGNsugoT90enKlR8/G36H0kTxPthDhmtNUCwEHvgRza5Cjpjoj+P2X6eMpFUDN7pFrJZsKadL4x990G8RBE1w==",
       "dependencies": {
         "@tediousjs/connection-string": "^0.5.0",
         "commander": "^11.0.0",
         "debug": "^4.3.3",
         "rfdc": "^1.3.0",
         "tarn": "^3.0.2",
-        "tedious": "^16.4.0"
+        "tedious": "^18.2.1"
       },
       "bin": {
         "mssql": "bin/mssql"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/nanoid": {
@@ -6749,11 +6935,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/nodemon": {
       "version": "3.1.3",
@@ -6842,6 +7023,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6850,6 +7032,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6858,6 +7041,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -7115,6 +7299,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
       "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7355,6 +7540,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -7450,6 +7636,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -7486,6 +7673,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -7532,6 +7720,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -7567,6 +7756,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -7647,6 +7837,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -7664,6 +7855,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -7677,6 +7869,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -7759,24 +7952,23 @@
       }
     },
     "node_modules/tedious": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.7.1.tgz",
-      "integrity": "sha512-NmedZS0NJiTv3CoYnf1FtjxIDUgVYzEmavrc8q2WHRb+lP4deI9BpQfmNnBZZaWusDbP5FVFZCcvzb3xOlNVlQ==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-18.3.0.tgz",
+      "integrity": "sha512-/aVCX2VLu9Ihf5UyxifRXfmWQ1P8HNJvapk1as+LMzSdw9AmbNtEHllrffZpNrzBCptcK0Z4m06k+tutL2wowA==",
       "dependencies": {
-        "@azure/identity": "^3.4.1",
+        "@azure/core-auth": "^1.7.2",
+        "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.6.1",
+        "@types/node": ">=18",
+        "bl": "^6.0.11",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/text-table": {
@@ -7869,6 +8061,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -7882,6 +8075,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -7900,6 +8094,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -7919,6 +8114,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -7938,6 +8134,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -7955,9 +8152,9 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -8012,6 +8209,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -8027,6 +8225,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -8334,53 +8533,53 @@
       }
     },
     "@aws-sdk/client-lambda": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.609.0.tgz",
-      "integrity": "sha512-+us5UQmuZu7Qd33l9xt2TZ2TAT4LWY7QfjSCUaaR8/LRNG6af1LvKfdxSC5iYU+jjb6Yrc1FITH/IoNxbjD6NQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.631.0.tgz",
+      "integrity": "sha512-r34Bbuerxr664/+P6iDrwoIAvHcGPvelD79gJ6PteUYEjCXVzhKtcnzuJSq0FGK7+OUnq9F+TzdUA0AtkKWpNw==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
         "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "@smithy/util-utf8": "^3.0.0",
         "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
@@ -8451,44 +8650,44 @@
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-          "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+          "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -8496,45 +8695,45 @@
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-          "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+          "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -8542,46 +8741,46 @@
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-          "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+          "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/client-sso-oidc": "3.609.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/client-sso-oidc": "3.631.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -8589,23 +8788,26 @@
           }
         },
         "@aws-sdk/core": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-          "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+          "version": "3.629.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+          "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
           "requires": {
-            "@smithy/core": "^2.2.4",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/signature-v4": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "fast-xml-parser": "4.2.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "fast-xml-parser": "4.4.1",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-          "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+          "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -8614,88 +8816,88 @@
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-          "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+          "version": "3.622.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+          "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/node-http-handler": "^3.1.1",
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.5",
+            "@smithy/util-stream": "^3.1.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-          "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+          "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-          "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+          "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-ini": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-ini": "3.631.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-          "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+          "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-          "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+          "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
           "requires": {
-            "@aws-sdk/client-sso": "3.609.0",
-            "@aws-sdk/token-providers": "3.609.0",
+            "@aws-sdk/client-sso": "3.631.0",
+            "@aws-sdk/token-providers": "3.614.0",
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-          "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+          "version": "3.621.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+          "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -8704,12 +8906,12 @@
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-          "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+          "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -8725,35 +8927,35 @@
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-          "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+          "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-          "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+          "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@aws-sdk/util-endpoints": "3.631.0",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/region-config-resolver": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-          "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+          "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "@smithy/util-config-provider": "^3.0.0",
             "@smithy/util-middleware": "^3.0.3",
@@ -8761,13 +8963,13 @@
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-          "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+          "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -8782,13 +8984,13 @@
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-          "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+          "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-endpoints": "^2.0.5",
             "tslib": "^2.6.2"
           }
         },
@@ -8804,21 +9006,28 @@
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-          "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+          "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
           "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
             "tslib": "^2.6.2"
           }
         },
@@ -8829,70 +9038,88 @@
           "requires": {
             "@smithy/is-array-buffer": "^2.2.0",
             "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "requires": {
+            "strnum": "^1.0.5"
           }
         }
       }
     },
     "@aws-sdk/client-s3": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.609.0.tgz",
-      "integrity": "sha512-lh8NxL9qm8eSphEcsTGjNMArYRlga4yTZCr3d7UPCRFiV1oz3e0EIA5EnxSriYi9P5Houi5d9GSWtPOel2mAow==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.631.0.tgz",
+      "integrity": "sha512-VBZoG6oMMsL5zOvO8Wxxcpv4T/qmQiTv58C+7c4zaHsIM2lCzQsU042XwH/jenqPsse1FTM45HnanRDOLv99+w==",
       "requires": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.609.0",
-        "@aws-sdk/middleware-expect-continue": "3.609.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.620.0",
+        "@aws-sdk/middleware-expect-continue": "3.620.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.620.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-location-constraint": "3.609.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-sdk-s3": "3.609.0",
-        "@aws-sdk/middleware-signing": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-sdk-s3": "3.629.0",
         "@aws-sdk/middleware-ssec": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/signature-v4-multi-region": "3.609.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
+        "@aws-sdk/signature-v4-multi-region": "3.629.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
         "@aws-sdk/xml-builder": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/eventstream-serde-browser": "^3.0.4",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/eventstream-serde-browser": "^3.0.6",
         "@smithy/eventstream-serde-config-resolver": "^3.0.3",
-        "@smithy/eventstream-serde-node": "^3.0.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@smithy/eventstream-serde-node": "^3.0.5",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-blob-browser": "^3.1.2",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/hash-stream-node": "^3.1.2",
         "@smithy/invalid-dependency": "^3.0.3",
         "@smithy/md5-js": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
+        "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-stream": "^3.0.5",
+        "@smithy/util-stream": "^3.1.3",
         "@smithy/util-utf8": "^3.0.0",
         "@smithy/util-waiter": "^3.1.2",
         "tslib": "^2.6.2"
@@ -8963,44 +9190,44 @@
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-          "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+          "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -9008,45 +9235,45 @@
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-          "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+          "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -9054,46 +9281,46 @@
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-          "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+          "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/client-sso-oidc": "3.609.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/client-sso-oidc": "3.631.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -9101,23 +9328,26 @@
           }
         },
         "@aws-sdk/core": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-          "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+          "version": "3.629.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+          "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
           "requires": {
-            "@smithy/core": "^2.2.4",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/signature-v4": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "fast-xml-parser": "4.2.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "fast-xml-parser": "4.4.1",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-          "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+          "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -9126,88 +9356,88 @@
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-          "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+          "version": "3.622.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+          "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/node-http-handler": "^3.1.1",
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.5",
+            "@smithy/util-stream": "^3.1.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-          "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+          "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-          "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+          "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-ini": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-ini": "3.631.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-          "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+          "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-          "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+          "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
           "requires": {
-            "@aws-sdk/client-sso": "3.609.0",
-            "@aws-sdk/token-providers": "3.609.0",
+            "@aws-sdk/client-sso": "3.631.0",
+            "@aws-sdk/token-providers": "3.614.0",
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-          "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+          "version": "3.621.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+          "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -9216,12 +9446,12 @@
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-          "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+          "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -9237,35 +9467,35 @@
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-          "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+          "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-          "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+          "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@aws-sdk/util-endpoints": "3.631.0",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/region-config-resolver": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-          "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+          "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "@smithy/util-config-provider": "^3.0.0",
             "@smithy/util-middleware": "^3.0.3",
@@ -9273,13 +9503,13 @@
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-          "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+          "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -9294,13 +9524,13 @@
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-          "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+          "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-endpoints": "^2.0.5",
             "tslib": "^2.6.2"
           }
         },
@@ -9316,21 +9546,28 @@
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-          "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+          "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
           "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
             "tslib": "^2.6.2"
           }
         },
@@ -9341,52 +9578,70 @@
           "requires": {
             "@smithy/is-array-buffer": "^2.2.0",
             "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "requires": {
+            "strnum": "^1.0.5"
           }
         }
       }
     },
     "@aws-sdk/client-secrets-manager": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.609.0.tgz",
-      "integrity": "sha512-1vDLUl0TuZx7TATsYkIaKj9etNzTpFVF95FpfFnJeyen397tYLot5sUNkcMCJvOLbdNVnJo1o5F8GNfU776EIQ==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.631.0.tgz",
+      "integrity": "sha512-wNLWR3nohNeEkF3IPAAstvJT0rGTJ8RCpB3naPbdhbRoFwMRgzlvjtpPvLN19jJlvrHtpujISZAKrm7j01i8Yg==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -9459,44 +9714,44 @@
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-          "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+          "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -9504,45 +9759,45 @@
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-          "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+          "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -9550,46 +9805,46 @@
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-          "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+          "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/client-sso-oidc": "3.609.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/client-sso-oidc": "3.631.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -9597,23 +9852,26 @@
           }
         },
         "@aws-sdk/core": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-          "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+          "version": "3.629.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+          "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
           "requires": {
-            "@smithy/core": "^2.2.4",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/signature-v4": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "fast-xml-parser": "4.2.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "fast-xml-parser": "4.4.1",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-          "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+          "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -9622,88 +9880,88 @@
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-          "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+          "version": "3.622.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+          "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/node-http-handler": "^3.1.1",
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.5",
+            "@smithy/util-stream": "^3.1.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-          "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+          "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-          "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+          "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-ini": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-ini": "3.631.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-          "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+          "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-          "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+          "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
           "requires": {
-            "@aws-sdk/client-sso": "3.609.0",
-            "@aws-sdk/token-providers": "3.609.0",
+            "@aws-sdk/client-sso": "3.631.0",
+            "@aws-sdk/token-providers": "3.614.0",
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-          "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+          "version": "3.621.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+          "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -9712,12 +9970,12 @@
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-          "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+          "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -9733,35 +9991,35 @@
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-          "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+          "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-          "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+          "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@aws-sdk/util-endpoints": "3.631.0",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/region-config-resolver": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-          "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+          "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "@smithy/util-config-provider": "^3.0.0",
             "@smithy/util-middleware": "^3.0.3",
@@ -9769,13 +10027,13 @@
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-          "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+          "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -9790,13 +10048,13 @@
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-          "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+          "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-endpoints": "^2.0.5",
             "tslib": "^2.6.2"
           }
         },
@@ -9812,21 +10070,28 @@
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-          "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+          "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
           "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
             "tslib": "^2.6.2"
           }
         },
@@ -9837,52 +10102,70 @@
           "requires": {
             "@smithy/is-array-buffer": "^2.2.0",
             "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "requires": {
+            "strnum": "^1.0.5"
           }
         }
       }
     },
     "@aws-sdk/client-ses": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.609.0.tgz",
-      "integrity": "sha512-tfTfTl8IuKcOLFSlUA6XCSbzAVQ+MCdCl0Fme2Rd/GsKgB3Momyh4HcVHI09S5HaYTo/7P3ovJBOdv6JcKVDDw==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.631.0.tgz",
+      "integrity": "sha512-vS3hsW4OURlOosBpg+K87HA4AF1j5sUbmSUQJ9QMGS7oc06p62Td3n+Ne1dQwuohKil5OcKHLGzkQ61fYq58vQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
+        "@aws-sdk/client-sso-oidc": "3.631.0",
+        "@aws-sdk/client-sts": "3.631.0",
+        "@aws-sdk/core": "3.629.0",
+        "@aws-sdk/credential-provider-node": "3.631.0",
+        "@aws-sdk/middleware-host-header": "3.620.0",
         "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
+        "@aws-sdk/middleware-recursion-detection": "3.620.0",
+        "@aws-sdk/middleware-user-agent": "3.631.0",
+        "@aws-sdk/region-config-resolver": "3.614.0",
         "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
+        "@aws-sdk/util-endpoints": "3.631.0",
         "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
+        "@aws-sdk/util-user-agent-node": "3.614.0",
+        "@smithy/config-resolver": "^3.0.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
         "@smithy/hash-node": "^3.0.3",
         "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
+        "@smithy/middleware-content-length": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/node-http-handler": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/url-parser": "^3.0.3",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-body-length-browser": "^3.0.0",
         "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
+        "@smithy/util-defaults-mode-browser": "^3.0.14",
+        "@smithy/util-defaults-mode-node": "^3.0.14",
+        "@smithy/util-endpoints": "^2.0.5",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
         "@smithy/util-utf8": "^3.0.0",
@@ -9955,44 +10238,44 @@
           }
         },
         "@aws-sdk/client-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-          "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.631.0.tgz",
+          "integrity": "sha512-tpXRQMbbTsKED6GGF0rZbg9Nr0DRCWImopX2lVh4deIeHQfNxeOtq2brqDWiPD593I190xeL/HMChSOmvDXNAw==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -10000,45 +10283,45 @@
           }
         },
         "@aws-sdk/client-sso-oidc": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-          "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.631.0.tgz",
+          "integrity": "sha512-afJAssIvsHibVq65qO3Q31NCfSTsPEnyr+PT80uGVAkKev1PJI1AjsxBGUTLtPMV8lrzDzDx5CG9ax1AZ3LG6w==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -10046,46 +10329,46 @@
           }
         },
         "@aws-sdk/client-sts": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-          "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.631.0.tgz",
+          "integrity": "sha512-Zo/2XDrmNpnSRlQLL8XOCJxuN7UIrGKf4itdjHqtEmD2PqstnYe6IMeEVOELpZ8iktjvsIrVr+qxlIX1QlmgCQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "5.2.0",
             "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/client-sso-oidc": "3.609.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
+            "@aws-sdk/client-sso-oidc": "3.631.0",
+            "@aws-sdk/core": "3.629.0",
+            "@aws-sdk/credential-provider-node": "3.631.0",
+            "@aws-sdk/middleware-host-header": "3.620.0",
             "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
+            "@aws-sdk/middleware-recursion-detection": "3.620.0",
+            "@aws-sdk/middleware-user-agent": "3.631.0",
+            "@aws-sdk/region-config-resolver": "3.614.0",
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
+            "@aws-sdk/util-endpoints": "3.631.0",
             "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
+            "@aws-sdk/util-user-agent-node": "3.614.0",
+            "@smithy/config-resolver": "^3.0.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/fetch-http-handler": "^3.2.4",
             "@smithy/hash-node": "^3.0.3",
             "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
+            "@smithy/middleware-content-length": "^3.0.5",
+            "@smithy/middleware-endpoint": "^3.1.0",
+            "@smithy/middleware-retry": "^3.0.14",
             "@smithy/middleware-serde": "^3.0.3",
             "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/node-http-handler": "^3.1.4",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
             "@smithy/url-parser": "^3.0.3",
             "@smithy/util-base64": "^3.0.0",
             "@smithy/util-body-length-browser": "^3.0.0",
             "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-defaults-mode-browser": "^3.0.14",
+            "@smithy/util-defaults-mode-node": "^3.0.14",
+            "@smithy/util-endpoints": "^2.0.5",
             "@smithy/util-middleware": "^3.0.3",
             "@smithy/util-retry": "^3.0.3",
             "@smithy/util-utf8": "^3.0.0",
@@ -10093,23 +10376,26 @@
           }
         },
         "@aws-sdk/core": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-          "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
+          "version": "3.629.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+          "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
           "requires": {
-            "@smithy/core": "^2.2.4",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/core": "^2.3.2",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/signature-v4": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "fast-xml-parser": "4.2.5",
+            "@smithy/util-middleware": "^3.0.3",
+            "fast-xml-parser": "4.4.1",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-env": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-          "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
+          "integrity": "sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -10118,88 +10404,88 @@
           }
         },
         "@aws-sdk/credential-provider-http": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-          "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
+          "version": "3.622.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.622.0.tgz",
+          "integrity": "sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/node-http-handler": "^3.1.1",
+            "@smithy/fetch-http-handler": "^3.2.4",
+            "@smithy/node-http-handler": "^3.1.4",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.5",
+            "@smithy/util-stream": "^3.1.3",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-ini": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-          "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.631.0.tgz",
+          "integrity": "sha512-34NmRl6GYlyKTHwiA3C3MjCtmXfoaOXI8b2h7P9eAC8leuIb/51v482g0K6X5P5FqaGY8ZreUq5BMsGjBRr1uQ==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-          "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.631.0.tgz",
+          "integrity": "sha512-MlYcFknrMQ8RUVe0DMPE09mX8+97s7MLwnVV8l+LFi7m+ZfBz+h6LrohhOXC5elJHf4G3T0r/9Rwct63+zHK/w==",
           "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-ini": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
+            "@aws-sdk/credential-provider-env": "3.620.1",
+            "@aws-sdk/credential-provider-http": "3.622.0",
+            "@aws-sdk/credential-provider-ini": "3.631.0",
+            "@aws-sdk/credential-provider-process": "3.620.1",
+            "@aws-sdk/credential-provider-sso": "3.631.0",
+            "@aws-sdk/credential-provider-web-identity": "3.621.0",
             "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
+            "@smithy/credential-provider-imds": "^3.2.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-process": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-          "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
+          "version": "3.620.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.620.1.tgz",
+          "integrity": "sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-          "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.631.0.tgz",
+          "integrity": "sha512-k3Mj1Fc7faVOGR+qrwROir/8No35G7gbVL5FuY467x3y0ELa/6w0j/0HM+5eqzGABW7pSL/OHONhWKlYwg7Gkw==",
           "requires": {
-            "@aws-sdk/client-sso": "3.609.0",
-            "@aws-sdk/token-providers": "3.609.0",
+            "@aws-sdk/client-sso": "3.631.0",
+            "@aws-sdk/token-providers": "3.614.0",
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-          "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
+          "version": "3.621.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.621.0.tgz",
+          "integrity": "sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
@@ -10208,12 +10494,12 @@
           }
         },
         "@aws-sdk/middleware-host-header": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-          "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.620.0.tgz",
+          "integrity": "sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -10229,35 +10515,35 @@
           }
         },
         "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-          "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
+          "version": "3.620.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.620.0.tgz",
+          "integrity": "sha512-nh91S7aGK3e/o1ck64sA/CyoFw+gAYj2BDOnoNa6ouyCrVJED96ZXWbhye/fz9SgmNUZR2g7GdVpiLpMKZoI5w==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/middleware-user-agent": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-          "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.631.0.tgz",
+          "integrity": "sha512-mpFRFaP9fjXhw8NiRTP+lBPKRKMSKzfCyTXQXrQCSo4fAUaz8LPCc8VdqyoNmx4CLBTRflbEHLx5PfInA0DsrA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
+            "@aws-sdk/util-endpoints": "3.631.0",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
         "@aws-sdk/region-config-resolver": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-          "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.614.0.tgz",
+          "integrity": "sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "@smithy/util-config-provider": "^3.0.0",
             "@smithy/util-middleware": "^3.0.3",
@@ -10265,13 +10551,13 @@
           }
         },
         "@aws-sdk/token-providers": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-          "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.614.0.tgz",
+          "integrity": "sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
+            "@smithy/shared-ini-file-loader": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
@@ -10286,13 +10572,13 @@
           }
         },
         "@aws-sdk/util-endpoints": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-          "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
+          "version": "3.631.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.631.0.tgz",
+          "integrity": "sha512-aavsyk17lK/r6rfVFYLh6/Y0eWvtbclWteJyW9PQLo5mpHPcTj6IbqMN4LHV27Y9IF7oOlbEAQ1CGTfpUlOvTg==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
             "@smithy/types": "^3.3.0",
-            "@smithy/util-endpoints": "^2.0.4",
+            "@smithy/util-endpoints": "^2.0.5",
             "tslib": "^2.6.2"
           }
         },
@@ -10308,21 +10594,28 @@
           }
         },
         "@aws-sdk/util-user-agent-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-          "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
+          "version": "3.614.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.614.0.tgz",
+          "integrity": "sha512-15ElZT88peoHnq5TEoEtZwoXTXRxNrk60TZNdpl/TUBJ5oNJ9Dqb5Z4ryb8ofN6nm9aFf59GVAerFDz8iUoHBA==",
           "requires": {
             "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
+            "@smithy/node-config-provider": "^3.1.4",
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
         },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
           "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
             "tslib": "^2.6.2"
           }
         },
@@ -10333,6 +10626,24 @@
           "requires": {
             "@smithy/is-array-buffer": "^2.2.0",
             "tslib": "^2.6.2"
+          },
+          "dependencies": {
+            "@smithy/is-array-buffer": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+              "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+              "requires": {
+                "tslib": "^2.6.2"
+              }
+            }
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "requires": {
+            "strnum": "^1.0.5"
           }
         }
       }
@@ -10641,13 +10952,13 @@
       }
     },
     "@aws-sdk/lib-storage": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.609.0.tgz",
-      "integrity": "sha512-572EZF6x9PtDfRbRAlBx1ZNpolA6Ol3kUmZZT6lStMTsgLiAss7lJlp35eAdPTUMIREcY9E2hEbI7imPS2506g==",
+      "version": "3.631.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.631.0.tgz",
+      "integrity": "sha512-B3sZoKqqoe2o8MLdOsUVdZzmbnjcQv+tbexbCOQxIDXBp+5QQAaYgkTRrxdqkmb73AUNw+mlfevyNdwgrx3PNg==",
       "requires": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -10655,14 +10966,14 @@
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.609.0.tgz",
-      "integrity": "sha512-QhHRfr4e7FqaMUAnOAFdQVOR3yDLw40i1IZPo+TeiKyev9LEyYEX2l6DbdaIwAztofOpAxfFNj/IJ0V/efzz/w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.620.0.tgz",
+      "integrity": "sha512-eGLL0W6L3HDb3OACyetZYOWpHJ+gLo0TehQKeQyy2G8vTYXqNTeqYhuI6up9HVjBzU9eQiULVQETmgQs7TFaRg==",
       "requires": {
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
         "tslib": "^2.6.2"
@@ -10680,12 +10991,12 @@
       }
     },
     "@aws-sdk/middleware-expect-continue": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.609.0.tgz",
-      "integrity": "sha512-+zeg//mSer4JZRxOB/4mUOMUJyuYPwATnIC5moBB8P8Xe+mJaVRFy8qlCtzYNj2TycnlsBPzTK0j7P1yvDh97w==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.620.0.tgz",
+      "integrity": "sha512-QXeRFMLfyQ31nAHLbiTLtk0oHzG9QLMaof5jIfqcUwnOkO8YnQdeqzakrg1Alpy/VQ7aqzIi8qypkBe2KXZz0A==",
       "requires": {
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -10702,15 +11013,15 @@
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.609.0.tgz",
-      "integrity": "sha512-TJ4WE+ehT+qcrhr7/yJCzmJJPmUoPPWIbCnFzqGxauH/dpVBCslmd1vZg3h2VnfRiaDkc6f68dqYVc29CaurhQ==",
+      "version": "3.620.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.620.0.tgz",
+      "integrity": "sha512-ftz+NW7qka2sVuwnnO1IzBku5ccP+s5qZGeRTPgrKB7OzRW85gthvIo1vQR2w+OwHFk7WJbbhhWwbCbktnP4UA==",
       "requires": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-sdk/types": "3.609.0",
         "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
@@ -10781,21 +11092,43 @@
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.609.0.tgz",
-      "integrity": "sha512-kvwjL6OJFhAGWoYaIWR7HmILjiVk6xVj6QEU6qZMA7FtGgvlKi4pLfs8Of+hQqo+2TEhUoxG/5t6WqwB8uxjsw==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.629.0.tgz",
+      "integrity": "sha512-FRXLcnPWXBoq/T9mnGnrpqhrSKNSm22rqJ0L7P14KESmbGuwhF/7ELYYxXIpgnIpb/CIUVmIU5EE8lsW1VTe8A==",
       "requires": {
+        "@aws-sdk/core": "3.629.0",
         "@aws-sdk/types": "3.609.0",
         "@aws-sdk/util-arn-parser": "3.568.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
+        "@smithy/core": "^2.3.2",
+        "@smithy/node-config-provider": "^3.1.4",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.3",
+        "@smithy/util-stream": "^3.1.3",
+        "@smithy/util-utf8": "^3.0.0",
         "tslib": "^2.6.2"
       },
       "dependencies": {
+        "@aws-sdk/core": {
+          "version": "3.629.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.629.0.tgz",
+          "integrity": "sha512-+/ShPU/tyIBM3oY1cnjgNA/tFyHtlWq+wXF9xEKRv19NOpYbWQ+xzNwVjGq8vR07cCRqy/sDQLWPhxjtuV/FiQ==",
+          "requires": {
+            "@smithy/core": "^2.3.2",
+            "@smithy/node-config-provider": "^3.1.4",
+            "@smithy/property-provider": "^3.1.3",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/signature-v4": "^4.1.0",
+            "@smithy/smithy-client": "^3.1.12",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "fast-xml-parser": "4.4.1",
+            "tslib": "^2.6.2"
+          }
+        },
         "@aws-sdk/types": {
           "version": "3.609.0",
           "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
@@ -10804,30 +11137,28 @@
             "@smithy/types": "^3.3.0",
             "tslib": "^2.6.2"
           }
-        }
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.609.0.tgz",
-      "integrity": "sha512-2w3dBLjQVKIajYzokO4hduq8/0hSMUYHHmIo1Kdl+MSY8uwRBt12bLL6pyreobTcRMxizvn2ph/CQ9I1ST/WGQ==",
-      "requires": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-          "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
+        },
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
           "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
             "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
             "tslib": "^2.6.2"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+          "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+          "requires": {
+            "strnum": "^1.0.5"
           }
         }
       }
@@ -10879,14 +11210,14 @@
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.609.0.tgz",
-      "integrity": "sha512-FJs0BxVMyYOKNu7nzFI1kehfgWoYmdto5B8BSS29geUACF7jlOoeCfNZWVrnMjvAxVlSQ5O7Mr575932BnsycA==",
+      "version": "3.629.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.629.0.tgz",
+      "integrity": "sha512-GPX6dnmuLGDFp7CsGqGCzleEoNyr9ekgOzSBtcL5nKX++NruxO7f1QzJAbcYvz0gdKvz958UO0EKsGM6hnkTSg==",
       "requires": {
-        "@aws-sdk/middleware-sdk-s3": "3.609.0",
+        "@aws-sdk/middleware-sdk-s3": "3.629.0",
         "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/signature-v4": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       },
@@ -10897,6 +11228,21 @@
           "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
           "requires": {
             "@smithy/types": "^3.3.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/signature-v4": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.0.tgz",
+          "integrity": "sha512-aRryp2XNZeRcOtuJoxjydO6QTaVhxx/vjaR+gx7ZjaFgrgPRyZ3HCTbfwqYj6ZWEBHkCSUfcaymKPURaByukag==",
+          "requires": {
+            "@smithy/is-array-buffer": "^3.0.0",
+            "@smithy/protocol-http": "^4.1.0",
+            "@smithy/types": "^3.3.0",
+            "@smithy/util-hex-encoding": "^3.0.0",
+            "@smithy/util-middleware": "^3.0.3",
+            "@smithy/util-uri-escape": "^3.0.0",
+            "@smithy/util-utf8": "^3.0.0",
             "tslib": "^2.6.2"
           }
         }
@@ -10990,11 +11336,11 @@
       }
     },
     "@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "requires": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       }
     },
     "@azure/core-auth": {
@@ -11005,16 +11351,6 @@
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@azure/abort-controller": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-          "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@azure/core-client": {
@@ -11029,16 +11365,6 @@
         "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@azure/abort-controller": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-          "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@azure/core-http-compat": {
@@ -11049,16 +11375,6 @@
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-client": "^1.3.0",
         "@azure/core-rest-pipeline": "^1.3.0"
-      },
-      "dependencies": {
-        "@azure/abort-controller": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-          "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@azure/core-lro": {
@@ -11070,16 +11386,6 @@
         "@azure/core-util": "^1.2.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@azure/abort-controller": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-          "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@azure/core-paging": {
@@ -11091,9 +11397,9 @@
       }
     },
     "@azure/core-rest-pipeline": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.1.tgz",
-      "integrity": "sha512-ExPSbgjwCoht6kB7B4MeZoBAxcQSIl29r/bPeazZJx50ej4JJCByimLOrZoIsurISNyJQQHf30b3JfqC3Hb88A==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.3.tgz",
+      "integrity": "sha512-VxLk4AHLyqcHsfKe4MZ6IQ+D+ShuByy+RfStKfSjxJoL3WBWq17VNmrz8aT8etKzqc2nAeIyLxScjpzsS4fz8w==",
       "requires": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
@@ -11103,16 +11409,6 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@azure/abort-controller": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-          "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@azure/core-tracing": {
@@ -11124,43 +11420,43 @@
       }
     },
     "@azure/core-util": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
-      "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.2.tgz",
+      "integrity": "sha512-l1Qrqhi4x1aekkV+OlcqsJa4AnAkj5p0JV8omgwjaV9OAbP41lvrMvs+CptfetKkeEaGRGSzby7sjPZEX7+kkQ==",
       "requires": {
         "@azure/abort-controller": "^2.0.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@azure/abort-controller": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
-          "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
     "@azure/identity": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-3.4.2.tgz",
-      "integrity": "sha512-0q5DL4uyR0EZ4RXQKD8MadGH6zTIcloUoS/RVbCpNpej4pwte0xpqYxk8K97Py2RiuUvI7F4GXpoT4046VfufA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.4.1.tgz",
+      "integrity": "sha512-DwnG4cKFEM7S3T+9u05NstXU/HN0dk45kPOinUyNKsn5VWwpXd9sbPKEg6kgJzGbm1lMuhx9o31PVbCtM5sfBA==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
+        "@azure/core-client": "^1.9.2",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
+        "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
+        "@azure/msal-browser": "^3.14.0",
+        "@azure/msal-node": "^2.9.2",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
         "stoppable": "^1.1.0",
         "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+          "requires": {
+            "tslib": "^2.2.0"
+          }
+        }
       }
     },
     "@azure/keyvault-keys": {
@@ -11179,35 +11475,45 @@
         "@azure/core-util": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "@azure/abort-controller": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+          "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+          "requires": {
+            "tslib": "^2.2.0"
+          }
+        }
       }
     },
     "@azure/logger": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.2.tgz",
-      "integrity": "sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
+      "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
       "requires": {
         "tslib": "^2.6.2"
       }
     },
     "@azure/msal-browser": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.18.0.tgz",
-      "integrity": "sha512-jvK5bDUWbpOaJt2Io/rjcaOVcUzkqkrCme/WntdV1SMUc67AiTcEdKuY6G/nMQ7N5Cfsk9SfpugflQwDku53yg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.21.0.tgz",
+      "integrity": "sha512-BAwcFsVvOrYzKuUZHhFuvRykUmQGq6lDxst2qGnjxnpNZc3d/tnVPcmhgvUdeKl28VSE0ltgBzT3HkdpDtz9rg==",
       "requires": {
-        "@azure/msal-common": "14.13.0"
+        "@azure/msal-common": "14.14.1"
       }
     },
     "@azure/msal-common": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
-      "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA=="
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.14.1.tgz",
+      "integrity": "sha512-2Q3tqNz/PZLfSr8BvcHZVpRRfSn4MjGSqjj9J+HlBsmbf1Uu4P0WeXnemjTJwwx9KrmplsrN3UkZ/LPOR720rw=="
     },
     "@azure/msal-node": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
-      "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.13.0.tgz",
+      "integrity": "sha512-DhP97ycs7qlCVzzzWGzJiwAFyFj5okno74E4FUZ61oCLfKh4IxA1kxirqzrWuYZWpBe9HVPL6GA4NvmlEOBN5Q==",
       "requires": {
-        "@azure/msal-common": "14.13.0",
+        "@azure/msal-common": "14.14.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -11220,9 +11526,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
-      "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg=="
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ=="
     },
     "@babel/helper-validator-identifier": {
       "version": "7.24.7",
@@ -11230,16 +11536,19 @@
       "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w=="
     },
     "@babel/parser": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
-      "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw=="
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
+      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "requires": {
+        "@babel/types": "^7.25.2"
+      }
     },
     "@babel/types": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
-      "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
+      "version": "7.25.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
+      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
       "requires": {
-        "@babel/helper-string-parser": "^7.24.7",
+        "@babel/helper-string-parser": "^7.24.8",
         "@babel/helper-validator-identifier": "^7.24.7",
         "to-fast-properties": "^2.0.0"
       }
@@ -11375,24 +11684,24 @@
       }
     },
     "@smithy/core": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.6.tgz",
-      "integrity": "sha512-tBbVIv/ui7/lLTKayYJJvi8JLVL2SwOQTbNFEOrvzSE3ktByvsa1erwBOnAMo8N5Vu30g7lN4lLStrU75oDGuw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.3.2.tgz",
+      "integrity": "sha512-in5wwt6chDBcUv1Lw1+QzZxN9fBffi+qOixfb65yK4sDuKG7zAUO9HAFqmVzsZM3N+3tTyvZjtnDXePpvp007Q==",
       "requires": {
-        "@smithy/middleware-endpoint": "^3.0.5",
-        "@smithy/middleware-retry": "^3.0.9",
+        "@smithy/middleware-endpoint": "^3.1.0",
+        "@smithy/middleware-retry": "^3.0.14",
         "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/protocol-http": "^4.1.0",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/credential-provider-imds": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.4.tgz",
-      "integrity": "sha512-NKyH01m97Xa5xf3pB2QOF3lnuE8RIK0hTVNU5zvZAwZU8uspYO4DHQVlK+Y5gwSrujTfHvbfd1D9UFJAc0iYKQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.0.tgz",
+      "integrity": "sha512-0SCIzgd8LYZ9EJxUjLXBmEKSZR/P/w6l7Rz/pab9culE/RWuqelAKGJvn5qUOl8BgX8Yj5HWM50A5hiB/RzsgA==",
       "requires": {
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
@@ -11413,11 +11722,11 @@
       }
     },
     "@smithy/eventstream-serde-browser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.4.tgz",
-      "integrity": "sha512-Eo4anLZX6ltGJTZ5yJMc80gZPYYwBn44g0h7oFq6et+TYr5dUsTpIcDbz2evsOKIZhZ7zBoFWHtBXQ4QQeb5xA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-3.0.6.tgz",
+      "integrity": "sha512-2hM54UWQUOrki4BtsUI1WzmD13/SeaqT/AB3EUJKbcver/WgKNaiJ5y5F5XXuVe6UekffVzuUDrBZVAA3AWRpQ==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^3.0.4",
+        "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
@@ -11432,19 +11741,19 @@
       }
     },
     "@smithy/eventstream-serde-node": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.4.tgz",
-      "integrity": "sha512-mjlG0OzGAYuUpdUpflfb9zyLrBGgmQmrobNT8b42ZTsGv/J03+t24uhhtVEKG/b2jFtPIHF74Bq+VUtbzEKOKg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-3.0.5.tgz",
+      "integrity": "sha512-+upXvnHNyZP095s11jF5dhGw/Ihzqwl5G+/KtMnoQOpdfC3B5HYCcDVG9EmgkhJMXJlM64PyN5gjJl0uXFQehQ==",
       "requires": {
-        "@smithy/eventstream-serde-universal": "^3.0.4",
+        "@smithy/eventstream-serde-universal": "^3.0.5",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/eventstream-serde-universal": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.4.tgz",
-      "integrity": "sha512-Od9dv8zh3PgOD7Vj4T3HSuox16n0VG8jJIM2gvKASL6aCtcS8CfHZDWe1Ik3ZXW6xBouU+45Q5wgoliWDZiJ0A==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-3.0.5.tgz",
+      "integrity": "sha512-5u/nXbyoh1s4QxrvNre9V6vfyoLWuiVvvd5TlZjGThIikc3G+uNiG9uOTCWweSRjv1asdDIWK7nOmN7le4RYHQ==",
       "requires": {
         "@smithy/eventstream-codec": "^3.1.2",
         "@smithy/types": "^3.3.0",
@@ -11452,11 +11761,11 @@
       }
     },
     "@smithy/fetch-http-handler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-      "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.4.tgz",
+      "integrity": "sha512-kBprh5Gs5h7ug4nBWZi1FZthdqSM+T7zMmsZxx0IBvWUn7dK3diz2SHn7Bs4dQGFDk8plDv375gzenDoNwrXjg==",
       "requires": {
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
@@ -11523,19 +11832,19 @@
       }
     },
     "@smithy/middleware-content-length": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
-      "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.5.tgz",
+      "integrity": "sha512-ILEzC2eyxx6ncej3zZSwMpB5RJ0zuqH7eMptxC4KN3f+v9bqT8ohssKbhNR78k/2tWW+KS5Spw+tbPF4Ejyqvw==",
       "requires": {
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/middleware-endpoint": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.5.tgz",
-      "integrity": "sha512-V4acqqrh5tDxUEGVTOgf2lYMZqPQsoGntCrjrJZEeBzEzDry2d2vcI1QCXhGltXPPY+BMc6eksZMguA9fIY8vA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.0.tgz",
+      "integrity": "sha512-5y5aiKCEwg9TDPB4yFE7H6tYvGFf1OJHNczeY10/EFF8Ir8jZbNntQJxMWNfeQjC1mxPsaQ6mR9cvQbf+0YeMw==",
       "requires": {
         "@smithy/middleware-serde": "^3.0.3",
         "@smithy/node-config-provider": "^3.1.4",
@@ -11547,14 +11856,14 @@
       }
     },
     "@smithy/middleware-retry": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.9.tgz",
-      "integrity": "sha512-Mrv9omExU1gA7Y0VEJG2LieGfPYtwwcEiOnVGZ54a37NEMr66TJ0glFslOJFuKWG6izg5DpKIUmDV9rRxjm47Q==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.14.tgz",
+      "integrity": "sha512-7ZaWZJOjUxa5hgmuMspyt8v/zVsh0GXYuF7OvCmdcbVa/xbnKQoYC+uYKunAqRGTkxjOyuOCw9rmFUFOqqC0eQ==",
       "requires": {
         "@smithy/node-config-provider": "^3.1.4",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
         "@smithy/util-retry": "^3.0.3",
@@ -11592,12 +11901,12 @@
       }
     },
     "@smithy/node-http-handler": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.2.tgz",
-      "integrity": "sha512-Td3rUNI7qqtoSLTsJBtsyfoG4cF/XMFmJr6Z2dX8QNzIi6tIW6YmuyFml8mJ2cNpyWNqITKbROMOFrvQjmsOvw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.4.tgz",
+      "integrity": "sha512-+UmxgixgOr/yLsUxcEKGH0fMNVteJFGkmRltYFHnBMlogyFdpzn2CwqWmxOrfJELhV34v0WSlaqG1UtE1uXlJg==",
       "requires": {
         "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/querystring-builder": "^3.0.3",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -11613,9 +11922,9 @@
       }
     },
     "@smithy/protocol-http": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
-      "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.0.tgz",
+      "integrity": "sha512-dPVoHYQ2wcHooGXg3LQisa1hH0e4y0pAddPMeeUPipI1tEOqL6A4N0/G7abeq+K8wrwSgjk4C0wnD1XZpJm5aA==",
       "requires": {
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
@@ -11672,15 +11981,15 @@
       }
     },
     "@smithy/smithy-client": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.7.tgz",
-      "integrity": "sha512-nZbJZB0XI3YnaFBWGDBr7kjaew6O0oNYNmopyIz6gKZEbxzrtH7rwvU1GcVxcSFoOwWecLJEe79fxEMljHopFQ==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.12.tgz",
+      "integrity": "sha512-wtm8JtsycthkHy1YA4zjIh2thJgIQ9vGkoR639DBx5lLlLNU0v4GARpQZkr2WjXue74nZ7MiTSWfVrLkyD8RkA==",
       "requires": {
-        "@smithy/middleware-endpoint": "^3.0.5",
+        "@smithy/middleware-endpoint": "^3.1.0",
         "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
+        "@smithy/protocol-http": "^4.1.0",
         "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.6",
+        "@smithy/util-stream": "^3.1.3",
         "tslib": "^2.6.2"
       }
     },
@@ -11746,27 +12055,27 @@
       }
     },
     "@smithy/util-defaults-mode-browser": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.9.tgz",
-      "integrity": "sha512-WKPcElz92MAQG09miBdb0GxEH/MwD5GfE8g07WokITq5g6J1ROQfYCKC1wNnkqAGfrSywT7L0rdvvqlBplqiyA==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.14.tgz",
+      "integrity": "sha512-0iwTgKKmAIf+vFLV8fji21Jb2px11ktKVxbX6LIDPAUJyWQqGqBVfwba7xwa1f2FZUoolYQgLvxQEpJycXuQ5w==",
       "requires": {
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "@smithy/util-defaults-mode-node": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.9.tgz",
-      "integrity": "sha512-dQLrUqFxqpf0GvEKEuFdgXcdZwz6oFm752h4d6C7lQz+RLddf761L2r7dSwGWzESMMB3wKj0jL+skRhEGlecjw==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.14.tgz",
+      "integrity": "sha512-e9uQarJKfXApkTMMruIdxHprhcXivH1flYCe8JRDTzkkLx8dA3V5J8GZlST9yfDiRWkJpZJlUXGN9Rc9Ade3OQ==",
       "requires": {
         "@smithy/config-resolver": "^3.0.5",
-        "@smithy/credential-provider-imds": "^3.1.4",
+        "@smithy/credential-provider-imds": "^3.2.0",
         "@smithy/node-config-provider": "^3.1.4",
         "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.7",
+        "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "tslib": "^2.6.2"
       }
@@ -11809,12 +12118,12 @@
       }
     },
     "@smithy/util-stream": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.6.tgz",
-      "integrity": "sha512-w9i//7egejAIvplX821rPWWgaiY1dxsQUw0hXX7qwa/uZ9U3zplqTQ871jWadkcVB9gFDhkPWYVZf4yfFbZ0xA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.3.tgz",
+      "integrity": "sha512-FIv/bRhIlAxC0U7xM1BCnF2aDRPq0UaelqBHkM2lsCp26mcBbgI0tCVTv+jGdsQLUmAMybua/bjDsSu8RQHbmw==",
       "requires": {
-        "@smithy/fetch-http-handler": "^3.2.1",
-        "@smithy/node-http-handler": "^3.1.2",
+        "@smithy/fetch-http-handler": "^3.2.4",
+        "@smithy/node-http-handler": "^3.1.4",
         "@smithy/types": "^3.3.0",
         "@smithy/util-base64": "^3.0.0",
         "@smithy/util-buffer-from": "^3.0.0",
@@ -11862,17 +12171,17 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
+      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
       "requires": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.18.2"
       }
     },
     "@types/readable-stream": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.14.tgz",
-      "integrity": "sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.15.tgz",
+      "integrity": "sha512-oAZ3kw+kJFkEqyh7xORZOku1YAKvsFTogRY8kVl4vHpEKiDkfnSA/My8haRE7fvmix5Zyy+1pwzOi7yycGLBJw==",
       "requires": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
@@ -11961,6 +12270,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.5",
         "is-array-buffer": "^3.0.4"
@@ -12007,6 +12317,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.1",
         "call-bind": "^1.0.5",
@@ -12032,6 +12343,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "requires": {
         "possible-typed-array-names": "^1.0.0"
       }
@@ -12078,7 +12390,7 @@
         "@aws-sdk/client-sfn": "^3.592.0",
         "@aws-sdk/lib-storage": "^3.431.0",
         "aws-cron-parser": "^1.1.12",
-        "mssql": "^10.0.2",
+        "mssql": "^11.0.1",
         "nanoid": "^5.0.7",
         "pg": "^8.11.3",
         "pug": "^3.0.2",
@@ -12092,9 +12404,9 @@
       "dev": true
     },
     "bl": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.13.tgz",
-      "integrity": "sha512-tMncAcpsyjZgAVbVFupVIaB2xud13xxT59fdHkuszY2jdZkqIWfpQdmII1fOe3kOGAz0mNLTIHEm+KxpYsQKKg==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.14.tgz",
+      "integrity": "sha512-TJfbvGdL7KFGxTsEbsED7avqpFdY56q9IW0/aiytyheJzxST/+Io6cx/4Qx0K2/u0BPRDs65mjaQzYvMZeNocQ==",
       "requires": {
         "@types/readable-stream": "^4.0.0",
         "buffer": "^6.0.3",
@@ -12282,6 +12594,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -12292,6 +12605,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -12302,6 +12616,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -12341,6 +12656,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "requires": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -12373,6 +12689,7 @@
       "version": "1.23.3",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.1",
         "arraybuffer.prototype.slice": "^1.0.3",
@@ -12422,21 +12739,6 @@
         "which-typed-array": "^1.1.15"
       }
     },
-    "es-aggregate-error": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
-      "integrity": "sha512-KkzhUUuD2CUMqEc8JEqsXEMDHzDPE8RCjZeUBitsnB1eNcAJWQPiciKsMXe3Yytj4Flw1XLl46Qcf9OxvZha7A==",
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.2",
-        "set-function-name": "^2.0.2"
-      }
-    },
     "es-define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -12454,6 +12756,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0"
       }
@@ -12462,6 +12765,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
@@ -12481,6 +12785,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -12788,6 +13093,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -12814,6 +13120,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -12824,7 +13131,8 @@
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.2.4",
@@ -12842,6 +13150,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.5",
         "es-errors": "^1.3.0",
@@ -12884,6 +13193,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
       }
@@ -12913,7 +13223,8 @@
     "has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
     },
     "has-flag": {
       "version": "4.0.0",
@@ -13033,6 +13344,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
       "requires": {
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
@@ -13043,6 +13355,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1"
@@ -13052,6 +13365,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -13069,6 +13383,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -13077,7 +13392,8 @@
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
     },
     "is-core-module": {
       "version": "2.11.0",
@@ -13091,6 +13407,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
       "requires": {
         "is-typed-array": "^1.1.13"
       }
@@ -13099,6 +13416,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -13142,7 +13460,8 @@
     "is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -13154,6 +13473,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -13182,6 +13502,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7"
       }
@@ -13190,6 +13511,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -13198,6 +13520,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -13206,6 +13529,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
       "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dev": true,
       "requires": {
         "which-typed-array": "^1.1.14"
       }
@@ -13214,6 +13538,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -13229,7 +13554,8 @@
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -13261,11 +13587,6 @@
       "requires": {
         "argparse": "^2.0.1"
       }
-    },
-    "jsbi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -13325,9 +13646,9 @@
           }
         },
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
         }
       }
     },
@@ -13440,16 +13761,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mssql": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/mssql/-/mssql-10.0.4.tgz",
-      "integrity": "sha512-MhX5IcJ75/q+dUiOe+1ajpqjEe96ZKqMchYYPUIDU+Btqhwt4gbFeZhcGUZaRCEMV9uF+G8kLvaNSFaEzL9OXQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-11.0.1.tgz",
+      "integrity": "sha512-KlGNsugoT90enKlR8/G36H0kTxPthDhmtNUCwEHvgRza5Cjpjoj+P2X6eMpFUDN7pFrJZsKadL4x990G8RBE1w==",
       "requires": {
         "@tediousjs/connection-string": "^0.5.0",
         "commander": "^11.0.0",
         "debug": "^4.3.3",
         "rfdc": "^1.3.0",
         "tarn": "^3.0.2",
-        "tedious": "^16.4.0"
+        "tedious": "^18.2.1"
       }
     },
     "nanoid": {
@@ -13467,11 +13788,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "nodemon": {
       "version": "3.1.3",
@@ -13533,17 +13849,20 @@
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.5",
         "define-properties": "^1.2.1",
@@ -13725,7 +14044,8 @@
     "possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true
     },
     "postgres-array": {
       "version": "2.0.0",
@@ -13922,6 +14242,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.6",
         "define-properties": "^1.2.1",
@@ -13978,6 +14299,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "get-intrinsic": "^1.2.4",
@@ -13994,6 +14316,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.6",
         "es-errors": "^1.3.0",
@@ -14028,6 +14351,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
       "requires": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -14054,6 +14378,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -14114,6 +14439,7 @@
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14125,6 +14451,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14135,6 +14462,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -14187,21 +14515,20 @@
       "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="
     },
     "tedious": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-16.7.1.tgz",
-      "integrity": "sha512-NmedZS0NJiTv3CoYnf1FtjxIDUgVYzEmavrc8q2WHRb+lP4deI9BpQfmNnBZZaWusDbP5FVFZCcvzb3xOlNVlQ==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-18.3.0.tgz",
+      "integrity": "sha512-/aVCX2VLu9Ihf5UyxifRXfmWQ1P8HNJvapk1as+LMzSdw9AmbNtEHllrffZpNrzBCptcK0Z4m06k+tutL2wowA==",
       "requires": {
-        "@azure/identity": "^3.4.1",
+        "@azure/core-auth": "^1.7.2",
+        "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.6.1",
+        "@types/node": ">=18",
+        "bl": "^6.0.11",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.3"
       }
     },
     "text-table": {
@@ -14276,6 +14603,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
@@ -14286,6 +14614,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -14298,6 +14627,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",
@@ -14311,6 +14641,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.7",
         "for-each": "^0.3.3",
@@ -14324,6 +14655,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-bigints": "^1.0.2",
@@ -14338,9 +14670,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
+      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -14379,6 +14711,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -14391,6 +14724,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
       "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.7",

--- a/src/bedrock_common/makefile
+++ b/src/bedrock_common/makefile
@@ -1,6 +1,6 @@
 include ../make_variables
 
-dirs = bedrock_common packages table_copy encrypt
+dirs = bedrock_common packages table_copy encrypt packages_py
 
 .PHONY: $(dirs) init plan apply destroy clean
 

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -1,44 +1,41 @@
 # Deploy settings.
-INSTANCE = <UNIQUE INSTANCE STRING LIKE ej-test-0: lowercase alphanumeric characters and hyphens only>
-region = "us-east-1"
-statebucket = "avl-tfstate-store"
-account = 518970837364
-build_mode = std # Set to sam to build using SAM
+INSTANCE=<UNIQUE INSTANCE STRING LIKE ej-test-0: lowercase alphanumeric characters and hyphens only>
+region="us-east-1"
+statebucket="avl-tfstate-store"
+account=518970837364
+build_mode=std # Set to sam to build using SAM
 
 # The next four variables provide information on the VPC, subnets and security
 # groups that Bedrock will use. They can be created in the network folder and
 # the resulting output copied here, or you can use existing resources.
-BEDROCK_VPC_ID = "vpc-0340a3823e5b5f0d2"
-DB_SUBNET_GROUP_NAME =  "public-db-subnet-group"
-BEDROCK_SECURITY_GROUP_IDS = ["sg-076e12ba2a9012944"]
-BEDROCK_PRIVATE_SUBNETS = ["subnet-00e55df750014753d", "subnet-0c119b605ff498f3b"]
+BEDROCK_VPC_ID="vpc-0340a3823e5b5f0d2"
+DB_SUBNET_GROUP_NAME= "public-db-subnet-group"
+BEDROCK_SECURITY_GROUP_IDS=["sg-076e12ba2a9012944"]
+BEDROCK_PRIVATE_SUBNETS=["subnet-00e55df750014753d", "subnet-0c119b605ff498f3b"]
 
 # This section is for database connections.
 # If using the database built as part of this instance, you can copy from
 # ./db/make_variables.generated (but do not include the :5432).
 # If USER, PASSWORD and DB_NAME are not provided, the default values will be used.
 # Leave HOST blank to use the hard-coded production database.
-
-BEDROCK_DB_HOST=
-BEDROCK_DB_USER=
-BEDROCK_DB_PASSWORD=
-BEDROCK_DB_NAME=
-
+BEDROCK_DB_HOST=""
+BEDROCK_DB_USER=""
+BEDROCK_DB_PASSWORD=""
+BEDROCK_DB_NAME=""
 # Unlike the other DB variables, always include a schema name.
 BEDROCK_DB_SCHEMA="bedrock"
 
-# This is used in the API. The value can be read from 
-# src/etl/state_machine_variables.generated 
-# after creating the step function.
-STATE_MACHINE_ARN = "arn:aws:xxx"
+# This is used in the API. 
+# Can be read from the output of creating the step function in Terraform.
+STATE_MACHINE_ARN="arn:aws:xxx"
 
 # This is the directory (relative to the root of the project) where the data files are stored.
 data_directory='src/db/bedrock-db-data/data';
 
 # Email settings
-EMAIL_SENDER = "asheville_fake@ashevillenc.gov"
-EMAIL_RECIPIENT = "dummy@ashevillenc.gov"
+EMAIL_SENDER="asheville_fake@ashevillenc.gov"
+EMAIL_RECIPIENT="dummy@ashevillenc.gov"
 
 # Do not edit or delete the next line
-reverse = $(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
+reverse=$(if $(1),$(call reverse,$(wordlist 2,$(words $(1)),$(1)))) $(firstword $(1))
 


### PR DESCRIPTION
An API Key is now required to call the API.
Deploying the API reads the current value of the key from Secrets Manager. 

API now returns http statusCodes.

- 200 OK
- 401 Unauthorized
- 404 Not Found
- 204 No Content (for OPTIONS preflight)

For now failure to connect to the database will be a 404. It should be 500.