### PR TITLE
File Copy uses streaming and if_file_found flag

### DIFF
--- a/docs/etl_formats.md
+++ b/docs/etl_formats.md
@@ -78,6 +78,7 @@ The canonical store for all Bedrock assets is now in a separate repo: managed-da
           "description": null,
           "type": "table_copy",
           "email": "only_on_error", (OPTIONAL)
+          "email": "if_file_found", (OPTIONAL)
           "active": true,
           "source": {
             "asset": "ad_info.mun"
@@ -93,7 +94,10 @@ The canonical store for all Bedrock assets is now in a separate repo: managed-da
 
     - run_group_id looks up the run group to tell Bedrock when to run the ETL task.
     - The ETL job can have multiple tasks. For example, it might copy a table and then run an SQL script.
-    - The "email": "only_on_error" flag means that if the task is successful, there is no need to send an email. (By default an email is sent for every set of tasks run.) If there are tasks without the flag run at the same time, the email will be sent.
+    - The two "email" flags: "only_on_error" and "if_file_found" can control when emails are sent. 
+    - "only_on_error" means that if the task is successful, there is no need to send an email. (By default an email is sent for every set of tasks run.) 
+    - "if_file_found" is used when polling for a file, and when it appears send an email.
+    - If there are tasks without these flags run at the same time, the email will be sent.
 
 ## ETL Task Types
   The fields source, target, and configuration are used differently for different task types

--- a/src/etl/lambdas/create_etl_run_map/local.js
+++ b/src/etl/lambdas/create_etl_run_map/local.js
@@ -3,4 +3,5 @@ import { readFile } from 'fs/promises';
 
 let event = JSON.parse(await readFile("localtest.json", "utf8"));
 
-console.log( await lambda_handler(event));
+let results = await lambda_handler(event);
+console.log( JSON.stringify(results, null, 2) );

--- a/src/etl/lambdas/etl_email_results/sendEmails.js
+++ b/src/etl/lambdas/etl_email_results/sendEmails.js
@@ -8,8 +8,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url)); // current directory
 const compiledFunction = compileFile(join(__dirname, '/email.pug'));
 
 async function sendEmails(results) {
-  const totalResults = results?.failure?.length + results?.success?.length + results?.skipped?.length;
-  if (totalResults > 0) {
+  let noemail_list = results.noemail;
+  let email_list = results.success.concat(results.skipped).concat(results.failure.map(res => res.name));
+  let in_email_but_not_noemail = email_list.filter(item => !noemail_list.includes(item));
+  if (in_email_but_not_noemail.length > 0) {
     let emailRecip = [process.env.EMAIL_RECIPIENT];
     let emailSender = process.env.EMAIL_SENDER;
     let htmlEmail, emailSubject;
@@ -17,7 +19,6 @@ async function sendEmails(results) {
     results.failure = results.failure.map(res => res.name);
     results.failure.sort();
     results.success.sort();
-    results.noemail.sort();
     results.skipped.sort();
     emailSubject = "ETL Jobs Status: OK";
     if (results.skipped.length > 0 || results.failure.length > 0) {

--- a/src/etl/lambdas/etl_task_file_copy/.gitignore
+++ b/src/etl/lambdas/etl_task_file_copy/.gitignore
@@ -1,4 +1,1 @@
-.aws-sam/
-.terraform*
-*.zip
-.venv
+requirements.txt

--- a/src/etl/lambdas/etl_task_file_copy/README.md
+++ b/src/etl/lambdas/etl_task_file_copy/README.md
@@ -13,15 +13,15 @@ because the Crypto in SSH/SFTP in a Lambda requires a Linux native build.
 Set build_mode = sam in make_variables)
 
 ```
-terraform init
-terraform apply -var-file=ca.tfvars
+make init
+make apply
 ```
 
 ## Usage: Event structure to pass to Lambda
 
 s3_connection and ftp_connection refer to named connections in AWS Secrets Manager.
 
-Special note: ftp_path requires a slash at start and end, while path must have only a trailing slash.
+Special note: "path" for an FTP site requires a slash at start and end, while "path" for s3 must have only a trailing slash.
 
 
 

--- a/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
@@ -1,5 +1,5 @@
-import paramiko
-import re
+import paramiko  # SFTP
+import re        # RegEx
 import io
 import time 
 
@@ -41,10 +41,14 @@ def get_ftp(location):
             print('No recent source file matching pattern found')
             fileResult["fileFound"] = False
         else:
-            stream = sftp.open(location["path"] + source_file, mode='r') # , bufsize=1024)
+            stream = sftp.open(location["path"] + source_file, mode='r')
             print('Downloaded from FTP: ' + source_file)
             fileResult["stream"] = stream
+    except FileNotFoundError as err:
+        print('No source file found in FTP')
+        fileResult = { "fileFound": False, "fileName": None, "stream": None }            
     except BaseException as err:
+        # print(type(err))
         raise Exception("Get FTP Error: " + str(err))
 
     return fileResult

--- a/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_ftp.py
@@ -6,7 +6,6 @@ import time
 def get_ftp(location):
     try:
         sftp = connectToFTP(location["connection_data"])
-        file_to_get = location["tempfile"]
         source_file = location["filename"]
         if source_file.startswith("/"):
             pat = source_file[1:-1]
@@ -42,23 +41,25 @@ def get_ftp(location):
             print('No recent source file matching pattern found')
             fileResult["fileFound"] = False
         else:
-            sftp.get(location["path"] + source_file, file_to_get)
+            stream = sftp.open(location["path"] + source_file, mode='r') # , bufsize=1024)
             print('Downloaded from FTP: ' + source_file)
-
-        sftp.close() 
+            fileResult["stream"] = stream
     except BaseException as err:
         raise Exception("Get FTP Error: " + str(err))
 
     return fileResult
 
-def put_ftp(location):
+def put_ftp(location, from_stream):
     try:
         sftp = connectToFTP(location["connection_data"])
-        file_to_put = location["tempfile"]
-        sftp.put(file_to_put, location["path"] + location["filename"])
+        to_stream = sftp.open(location["path"] + location["filename"], mode='w')
+
+        for line in from_stream:
+            to_stream.write(line)
+        to_stream.close()
+        from_stream.close()
 
         print('Uploaded To FTP: ' + location["filename"])
-        sftp.close() 
     except BaseException as err:
         raise Exception("Put FTP Error: " + str(err))
 

--- a/src/etl/lambdas/etl_task_file_copy/copy_s3.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_s3.py
@@ -1,27 +1,33 @@
 import boto3
+import io
 
 s3 = boto3.client('s3')
         
 def download_s3(location):
-    fileResult = { "fileFound": True, "fileName": location["filename"] }
-    # TODO check if file is found
     try:
-        s3.download_file(
-            location["connection_data"]["s3_bucket"], 
-            location["path"] + location["filename"], 
-            location["tempfile"])
+        response = s3.get_object(
+            Bucket=location["connection_data"]["s3_bucket"], 
+            Key=location["path"] + location["filename"]
+            )
         print("File retrieved from S3: " + location["filename"])
+        stream = response['Body']
+        print(stream)
+        fileResult = { "fileFound": True, "fileName": location["filename"], "stream": stream }
+        return fileResult
+    except s3.exceptions.NoSuchKey as err:
+        print('No source file found in S3')
+        return { "fileFound": False, "fileName": None, "stream": None }
     except BaseException as err:
+        print(str(err))
         raise Exception("Download S3 Error: " + str(err))
-    
-    return fileResult
 
-def upload_s3(location):
+def upload_s3(location,stream):
     try:
-        s3.upload_file(
-            location["tempfile"], 
+        s3.upload_fileobj(
+            stream,
             location["connection_data"]["s3_bucket"], 
-            location["path"] + location["filename"])
+            location["path"] + location["filename"]
+            )
         print ('File loaded to S3: ' + location["filename"])
     except BaseException as err:
         raise Exception("Upload S3 Error: " + str(err))

--- a/src/etl/lambdas/etl_task_file_copy/copy_win.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_win.py
@@ -1,29 +1,32 @@
 from smb.SMBConnection import SMBConnection
+import io
 
 def get_win(location):
   fileResult = { "fileFound": True, "fileName": location["filename"] }
   # TODO check if file is found
   try:
+    stream = io.BytesIO()
     connection_data = location["connection_data"]
     share_name = connection_data['share_name']
     file_path = location["path"] + location["filename"]
-    tempfilename = location["tempfile"]
     conn = connectToWindows(connection_data)
-    file_obj = open(tempfilename,'wb')
-    file_attributes, filesize = conn.retrieveFile(share_name, file_path, file_obj)
+    conn.retrieveFile(share_name, file_path, stream)
+    stream.seek(0)
+    fileResult = { "fileFound": True, "fileName": location["filename"], "stream": stream }
+    print("File retrieved from Windows: " + location["filename"])
   except BaseException as err:
+    fileResult = { "fileFound": False, "fileName": location["filename"], "stream": None }
     raise Exception("Get Windows file share Error: " + str(err))
   return fileResult
 
-def put_win(location):
+def put_win(location,from_stream):
   try:
     connection_data = location["connection_data"]
     share_name = connection_data['share_name']
     file_path = location["path"] + location["filename"]
-    tempfilename = location["tempfile"]
     conn = connectToWindows(connection_data)
-    file_obj = open(tempfilename,'rb')
-    conn.storeFile(share_name, file_path, file_obj)
+    conn.storeFile(share_name, file_path, from_stream)
+    print("File uploaded to Windows: " + location["filename"])    
   except BaseException as err:
     raise Exception("Put Windows file share Error: " + str(err))
     

--- a/src/etl/lambdas/etl_task_file_copy/copy_win.py
+++ b/src/etl/lambdas/etl_task_file_copy/copy_win.py
@@ -1,4 +1,5 @@
 from smb.SMBConnection import SMBConnection
+from smb import smb_structs
 import io
 
 def get_win(location):
@@ -14,9 +15,12 @@ def get_win(location):
     stream.seek(0)
     fileResult = { "fileFound": True, "fileName": location["filename"], "stream": stream }
     print("File retrieved from Windows: " + location["filename"])
+  except smb_structs.OperationFailure as err:
+    print('No source file found in Windows')
+    fileResult = { "fileFound": False, "fileName": location["filename"], "stream": None }
   except BaseException as err:
     fileResult = { "fileFound": False, "fileName": location["filename"], "stream": None }
-    raise Exception("Get Windows file share Error: " + str(err))
+    raise Exception("Get Windows file share Error: " + str(type(err)))
   return fileResult
 
 def put_win(location,from_stream):

--- a/src/etl/lambdas/etl_task_file_copy/handler.py
+++ b/src/etl/lambdas/etl_task_file_copy/handler.py
@@ -90,7 +90,11 @@ def lambda_handler(event, context):
             else:
                 raise Exception("Invalid file copy connection type " + target_location["connection_data"]["type"])
         else:
-            print('No file found - skipping put')                    
+            print('No file found - skipping put')
+            return {
+                'statusCode': 404,
+                'body': 'No file found - skipping put'
+            }
 
         retmsg = ('File uploaded to ' +
             target_location["connection_data"]["type"] + ': ' +

--- a/src/etl/lambdas/etl_task_file_copy/handler.py
+++ b/src/etl/lambdas/etl_task_file_copy/handler.py
@@ -47,11 +47,10 @@ def lambda_handler(event, context):
                 'statusCode': 200,
                 'body': "Inactive: skipped"
             }
-        tempfile = fillDateTemplate('/tmp/temp${YYYY}${MM}${DD}${HH}${mm}${SS}.txt') 
-
+        
         locations = [
-          { "name": 'source_location', "tempfile": tempfile },
-          { "name": 'target_location', "tempfile": tempfile }
+          { "name": 'source_location' },
+          { "name": 'target_location' }
         ]
 
         for loc in locations:
@@ -70,31 +69,28 @@ def lambda_handler(event, context):
                 loc["config"] = location["config"]
 
         source_location = locations[0]
-        fileResult = None # Form: { fileFound: Bool, fileName: String }
+        fileResult = None # Form: { fileFound: Bool, fileName: String, stream: BytesIO }
         if source_location["connection_data"]["type"] == "s3":
-           fileResult = download_s3(source_location)
+            fileResult = download_s3(source_location)
         elif source_location["connection_data"]["type"] == "sftp":
-           fileResult = get_ftp(source_location)
+            fileResult = get_ftp(source_location)
         elif source_location["connection_data"]["type"] == "win":
-           fileResult = get_win(source_location)
+            fileResult = get_win(source_location)
         else:
             raise Exception("Invalid file copy connection type " + source_location["connection_data"]["type"])
-        
         target_location = locations[1]
         if (fileResult and fileResult["fileFound"]):
+            stream = fileResult["stream"]
             if target_location["connection_data"]["type"] == "s3":
-                upload_s3(target_location)
+                upload_s3(target_location,stream)
             elif target_location["connection_data"]["type"] == "sftp":
-                put_ftp(target_location)
+                put_ftp(target_location,stream)
             elif target_location["connection_data"]["type"] == "win":
-                put_win(target_location)
+                put_win(target_location,stream)
             else:
                 raise Exception("Invalid file copy connection type " + target_location["connection_data"]["type"])
         else:
-            print('No file found - skipping put')
-            
-        if os.path.exists(tempfile):
-                os.remove(tempfile)
+            print('No file found - skipping put')                    
 
         retmsg = ('File uploaded to ' +
             target_location["connection_data"]["type"] + ': ' +

--- a/src/etl/lambdas/etl_task_file_copy/local.py
+++ b/src/etl/lambdas/etl_task_file_copy/local.py
@@ -13,4 +13,5 @@ f = open(filename)
 event = json.load(f)
 f.close()
 
-lambda_handler(event, context)
+ret = lambda_handler(event, context)
+print(ret)

--- a/src/etl/lambdas/etl_task_file_copy/localtest.json
+++ b/src/etl/lambdas/etl_task_file_copy/localtest.json
@@ -10,9 +10,14 @@
           "connection": "A-2GKKZB3"
         },
         "target_location": {
-          "path": "/home/jon/",
-          "filename": "test.csv",
-          "connection": "hoopcha"
+          "path": "test/",
+          "filename": "moo.csv",
+          "connection": "s3_data_files"
+        },
+        "target_location2": {
+          "path": "/PROD/person.errors/",
+          "filename": "log.txt",
+          "connection": "telestaff_ftp"
         }
       }
     ]

--- a/src/etl/lambdas/etl_task_file_copy/localtest.json
+++ b/src/etl/lambdas/etl_task_file_copy/localtest.json
@@ -1,29 +1,21 @@
 {
-    "JobIsGo": true,
-    "ETLJob": {
-      "name": "everbridge.emp.ftp",
-      "run_group": "daily",
-      "depends": [
-      ],
-      "etl_tasks": [
-        {
-          "type": "file_copy",
-          "active": true,
-          "source_location": {
-            "asset": "everbridge.emp.s3",
-            "path": "everbridge/",
-            "filename": "avl.PR_City_Employees_Everbridge.csv",
-            "connection": "s3_data_files"
-          },
-          "target_location": {
-            "asset": "everbridge.emp.fake.s3",
-            "path": "everbridge/",
-            "filename": "avl.PR_City_Employees_Everbridge.copy.csv",
-            "connection": "s3_data_files"
-          }
+  "ETLJob": {
+    "etl_tasks": [
+      {
+        "type": "file_copy",
+        "active": true,
+        "source_location": {
+          "path": "/",
+          "filename": "test.csv",
+          "connection": "A-2GKKZB3"
+        },
+        "target_location": {
+          "path": "/home/jon/",
+          "filename": "test.csv",
+          "connection": "hoopcha"
         }
-      ]
-    },
-    "TaskIndex": 0,
-    "JobType": "file_copy"
+      }
+    ]
+  },
+  "TaskIndex": 0
 }

--- a/src/etl/lambdas/etl_task_file_copy/makefile
+++ b/src/etl/lambdas/etl_task_file_copy/makefile
@@ -1,7 +1,7 @@
 include ../../../make_variables
 
 dirs = build
-.PHONY: $(dirs) init plan apply destroy prebuild local clean
+.PHONY: $(dirs) init plan apply destroy prebuild local clean test
 
 SRC_DIR := ./deploy
 DEST_DIR := ./build
@@ -40,6 +40,9 @@ package: requirements.txt
 
 local: package
 	PYTHONPATH=./package python3 local.py
+
+run: package # To use: "make run run=somepythonfile.py"
+	PYTHONPATH=./package python3 $(run)
 
 clean:
 	rm -f *.instance

--- a/src/etl/lambdas/etl_task_sftp/.gitignore
+++ b/src/etl/lambdas/etl_task_sftp/.gitignore
@@ -1,4 +1,1 @@
-.aws-sam/
-.terraform*
-*.zip
-.venv
+requirements.txt

--- a/src/etl/lambdas/etl_task_sftp/requirements.txt
+++ b/src/etl/lambdas/etl_task_sftp/requirements.txt
@@ -1,4 +1,0 @@
-boto3
-paramiko
-pysmb
-wheel

--- a/src/etl/lambdas/update_etl_run_map/localtest.json
+++ b/src/etl/lambdas/update_etl_run_map/localtest.json
@@ -3,75 +3,29 @@
     "runsets": [
       [
         {
-          "name": "public_meeting_data.lib",
-          "run_group": "every15",
+          "name": "moo2",
+          "run_group": "moo",
           "depends": [
-            "public_meeting_data.goog"
+            "moo"
           ],
           "etl_tasks": [
             {
-              "type": "table_copy",
-              "active": true,
-              "email": "only_on_error",
-              "source_location": {
-                "asset": "public_meeting_data.goog",
-                "tab": "ActiveMeetings",
-                "range": "A2:W",
-                "filename": "public_meeting_data",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
-              },
-              "target_location": {
-                "asset": "public_meeting_data.lib",
-                "tablename": "public_meeting_data",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
-              }
-            },
-            {
-              "type": "table_copy",
+              "type": "file_copy",
               "active": true,
               "source_location": {
-                "asset": "public_meeting_data_archive.goog",
-                "tab": "MeetingArchive",
-                "range": "A2:W",
-                "filename": "public_meeting_data",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+                "asset": "moo",
+                "email": "if_file_found",
+                "path": "test/",
+                "filename": "moo_NO.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               },
               "target_location": {
-                "asset": "public_meeting_data.lib",
-                "append": true,
-                "tablename": "public_meeting_data",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
-              }
-            }
-          ]
-        },
-        {
-          "name": "public_meeting_data_categories.lib",
-          "run_group": "every15",
-          "depends": [
-            "public_meeting_data_categories.goog"
-          ],
-          "etl_tasks": [
-            {
-              "type": "table_copy",
-              "active": true,
-              "source_location": {
-                "asset": "public_meeting_data_categories.goog",
-                "tab": "CategoryValues",
-                "range": "A2:E",
-                "filename": "public_meeting_data_categories",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
-              },
-              "target_location": {
-                "asset": "public_meeting_data_categories.lib",
-                "tablename": "public_meeting_data_categories",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
+                "asset": "moo2",
+                "path": "test/",
+                "filename": "moo2.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               }
             }
           ]
@@ -79,51 +33,57 @@
       ],
       [
         {
-          "name": "public_meeting_data.pub",
-          "run_group": "every15",
+          "name": "moo3",
+          "run_group": "moo",
           "depends": [
-            "public_meeting_data.lib"
+            "moo2"
           ],
           "etl_tasks": [
             {
-              "type": "table_copy",
+              "type": "file_copy",
               "active": true,
               "source_location": {
-                "asset": "public_meeting_data.lib",
-                "tablename": "public_meeting_data",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
+                "asset": "moo2",
+                "path": "test/",
+                "filename": "moo2.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               },
               "target_location": {
-                "asset": "public_meeting_data.pub",
-                "tablename": "public_meeting_data",
-                "connection": "coa-publicdb1/coa_share/dbadmin",
-                "schemaname": "open"
+                "asset": "moo3",
+                "path": "test/",
+                "filename": "moo3.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               }
             }
           ]
-        },
+        }
+      ],
+      [
         {
-          "name": "public_meeting_data_categories.pub",
-          "run_group": "every15",
+          "name": "moo4",
+          "run_group": "moo",
           "depends": [
-            "public_meeting_data_categories.lib"
+            "moo3"
           ],
           "etl_tasks": [
             {
-              "type": "table_copy",
+              "type": "file_copy",
               "active": true,
               "source_location": {
-                "asset": "public_meeting_data_categories.lib",
-                "tablename": "public_meeting_data_categories",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
+                "asset": "moo3",
+                "path": "test/",
+                "filename": "moo3.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               },
               "target_location": {
-                "asset": "public_meeting_data_categories.pub",
-                "tablename": "public_meeting_data_categories",
-                "connection": "coa-publicdb1/coa_share/dbadmin",
-                "schemaname": "open"
+                "asset": "moo4",
+                "path": "test/",
+                "filename": "moo4.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               }
             }
           ]
@@ -139,203 +99,75 @@
       {
         "JobIsGo": false,
         "ETLJob": {
-          "name": "public_meeting_data.lib",
-          "run_group": "every15",
+          "name": "moo2",
+          "run_group": "moo",
           "depends": [
-            "public_meeting_data.goog"
+            "moo"
           ],
           "etl_tasks": [
             {
-              "type": "table_copy",
+              "type": "file_copy",
               "active": true,
               "source_location": {
-                "asset": "public_meeting_data.goog",
-                "tab": "ActiveMeetings",
-                "range": "A2:W",
-                "filename": "public_meeting_data",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+                "asset": "moo",
+                "email": "if_file_found",
+                "path": "test/",
+                "filename": "moo_NO.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               },
               "target_location": {
-                "asset": "public_meeting_data.lib",
-                "tablename": "public_meeting_data",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
+                "asset": "moo2",
+                "path": "test/",
+                "filename": "moo2.csv",
+                "connection": "s3_data_files",
+                "connection_id": "120a7bca9bbd89d15ae2"
               },
               "result": {
-                "statusCode": 200,
-                "body": {
-                  "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
-                }
-              }
-            },
-            {
-              "type": "table_copy",
-              "active": true,
-              "source_location": {
-                "asset": "public_meeting_data_archive.goog",
-                "tab": "MeetingArchive",
-                "range": "A2:W",
-                "filename": "public_meeting_data",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
-              },
-              "target_location": {
-                "asset": "public_meeting_data.lib",
-                "append": true,
-                "tablename": "public_meeting_data",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
-              },
-              "result": {
-                "statusCode": 200,
-                "body": {
-                  "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
-                }
-              }
-            }
-          ]
-        },
-        "TaskIndex": 1,
-        "JobType": "table_copy",
-        "results": {
-          "JobIsGo": false,
-          "ETLJob": {
-            "name": "public_meeting_data.lib",
-            "run_group": "every15",
-            "depends": [
-              "public_meeting_data.goog"
-            ],
-            "etl_tasks": [
-              {
-                "type": "table_copy",
-                "active": true,
-                "source_location": {
-                  "asset": "public_meeting_data.goog",
-                  "tab": "ActiveMeetings",
-                  "range": "A2:W",
-                  "filename": "public_meeting_data",
-                  "connection": "bedrock-googlesheets",
-                  "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
-                },
-                "target_location": {
-                  "asset": "public_meeting_data.lib",
-                  "tablename": "public_meeting_data",
-                  "connection": "pubrecdb1/mdastore1/dbadmin",
-                  "schemaname": "internal"
-                },
-                "result": {
-                  "statusCode": 200,
-                  "body": {
-                    "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
-                  }
-                }
-              },
-              {
-                "type": "table_copy",
-                "active": true,
-                "source_location": {
-                  "asset": "public_meeting_data_archive.goog",
-                  "tab": "MeetingArchive",
-                  "range": "A2:W",
-                  "filename": "public_meeting_data",
-                  "connection": "bedrock-googlesheets",
-                  "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
-                },
-                "target_location": {
-                  "asset": "public_meeting_data.lib",
-                  "append": true,
-                  "tablename": "public_meeting_data",
-                  "connection": "pubrecdb1/mdastore1/dbadmin",
-                  "schemaname": "internal"
-                },
-                "result": {
-                  "statusCode": 200,
-                  "body": {
-                    "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data"
-                  }
-                }
-              }
-            ]
-          },
-          "TaskIndex": 1,
-          "JobType": "table_copy"
-        }
-      },
-      {
-        "JobIsGo": false,
-        "ETLJob": {
-          "name": "public_meeting_data_categories.lib",
-          "run_group": "every15",
-          "depends": [
-            "public_meeting_data_categories.goog"
-          ],
-          "etl_tasks": [
-            {
-              "type": "table_copy",
-              "active": true,
-              "source_location": {
-                "asset": "public_meeting_data_categories.goog",
-                "tab": "CategoryValues",
-                "range": "A2:E",
-                "filename": "public_meeting_data_categories",
-                "connection": "bedrock-googlesheets",
-                "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
-              },
-              "target_location": {
-                "asset": "public_meeting_data_categories.lib",
-                "tablename": "public_meeting_data_categories",
-                "connection": "pubrecdb1/mdastore1/dbadmin",
-                "schemaname": "internal"
-              },
-              "result": {
-                "statusCode": 200,
-                "body": {
-                  "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data_categories"
-                }
+                "statusCode": 218,
+                "body": "No file found - skipping put"
               }
             }
           ]
         },
         "TaskIndex": 0,
-        "JobType": "table_copy",
+        "JobType": "file_copy",
         "results": {
           "JobIsGo": false,
           "ETLJob": {
-            "name": "public_meeting_data_categories.lib",
-            "run_group": "every15",
+            "name": "moo2",
+            "run_group": "moo",
             "depends": [
-              "public_meeting_data_categories.goog"
+              "moo"
             ],
             "etl_tasks": [
               {
-                "type": "table_copy",
+                "type": "file_copy",
                 "active": true,
                 "source_location": {
-                  "asset": "public_meeting_data_categories.goog",
-                  "tab": "CategoryValues",
-                  "range": "A2:E",
-                  "filename": "public_meeting_data_categories",
-                  "connection": "bedrock-googlesheets",
-                  "spreadsheetid": "11sK5YUKLDIA5cjzrXu_EzP5_5q_X1HbTPIkKyppR2SM"
+                  "asset": "moo",
+                  "email": "if_file_found",
+                  "path": "test/",
+                  "filename": "moo_NO.csv",
+                  "connection": "s3_data_files",
+                  "connection_id": "120a7bca9bbd89d15ae2"
                 },
                 "target_location": {
-                  "asset": "public_meeting_data_categories.lib",
-                  "tablename": "public_meeting_data_categories",
-                  "connection": "pubrecdb1/mdastore1/dbadmin",
-                  "schemaname": "internal"
+                  "asset": "moo2",
+                  "path": "test/",
+                  "filename": "moo2.csv",
+                  "connection": "s3_data_files",
+                  "connection_id": "120a7bca9bbd89d15ae2"
                 },
                 "result": {
-                  "statusCode": 200,
-                  "body": {
-                    "lambda_output": "Table copied pubrecdb1/mdastore1/dbadmin internal.public_meeting_data_categories"
-                  }
+                  "statusCode": 218,
+                  "body": "No file found - skipping put"
                 }
               }
             ]
           },
           "TaskIndex": 0,
-          "JobType": "table_copy"
+          "JobType": "file_copy"
         }
       }
     ]


### PR DESCRIPTION
File Copy has always used a temporary file, which limits how big the file can be. This converts it to streaming, which is how Table Copy already works.

The "email":"if_file_found" flag can now be used for polling for files and only sending an email when it appears.