### PR TITLE
Deleting asset returns list of deleted dependency relationships

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-console */
 import pgpkg from 'pg';
 import pgErrorCodes from '../pgErrorCodes.js';
-import { newClient, checkExistence, deleteInfo, checkBeforeDelete, getInfo } from '../utilities/utilities.js';
+import { newClient, checkExistence, deleteInfo } from '../utilities/utilities.js';
 
 async function handleDelete(tableNames, client, idField, idValue, name) {
   try {
@@ -49,7 +49,6 @@ async function getRelationsInfo(client, idField, idValue, name, tableName, idCol
 }
 
 function formatAncestors(ancestors) {
-  console.log('in format ancestors')
   return ancestors.map(obj => ({
     asset_id: obj.dependent_asset_id,
     asset_name: obj.asset_name
@@ -92,9 +91,7 @@ async function deleteAsset(
   }
 
   try {
-    console.log('before ce')
     await checkExistence(client, tableName, idField, idValue, name, shouldExist);
-    console.log('after ce')
 
   } catch (error) {
     await client.end();


### PR DESCRIPTION
Deleting asset returns lists of deleted dependency relationships.

Format looks like (though these are fake ids):
{
    "ancestors": [
        {
            "asset_id": "jf9-8udfs-dfe",
            "asset_name": "test parent"
        }
    ],
    "descendants": [
        {
            "asset_id": "adjfdafdadd",
            "asset_name": "test child"
        }
    ],
    "message": "Asset iouhdfapihdf successfully deleted. The following relationships have been removed from the dependencies table."
}

 
