### PR TITLE
added parent field to field list to fix post and put

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
@@ -28,7 +28,7 @@ async function handleAssetTypes(
   const name = 'asset type';
   const tableName = 'bedrock.asset_types';
   const requiredFields = ['asset_type_id', 'asset_type_name'];
-  const allFields = ['asset_type_id', 'asset_type_name'];
+  const allFields = ['asset_type_id', 'asset_type_name', 'parent'];
   const tableNameCustomFields = 'bedrock.asset_type_custom_fields';
 
   if (nParams === 2 && (pathElements[1] === null || pathElements[1].length === 0)) nParams = 1;


### PR DESCRIPTION
Parent type wasn't being added or updated for asset types. I think I left it off the list originally because I wasn't sure what we were doing with parent types. Or I just forgot it. In any case, re-added parent to the list of fields. 