### PR TITLE
changing get relations to only return PULLS_FROM relations

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/getExpandedRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getExpandedRelations.js
@@ -23,7 +23,8 @@ async function readRelations(db, idValue) {
   WITH RECURSIVE subdependencies AS (
     SELECT asset_id, asset_name, dependent_asset_id, dependency 
     FROM bedrock.dependency_view
-    WHERE asset_id = $1
+    WHERE asset_id = $1 
+    AND relation_type = 'PULLS_FROM'
     UNION
     SELECT d.asset_id, d.asset_name, d.dependent_asset_id, d.dependency
     FROM bedrock.dependency_view d
@@ -60,6 +61,7 @@ LEFT JOIN bedrock.run_groups r2 ON e2.run_group_id = r2.run_group_id
         SELECT asset_id, asset_name, dependent_asset_id, dependency 
         FROM bedrock.dependency_view
         WHERE dependent_asset_id = $1
+        AND relation_type = 'PULLS_FROM'
         UNION
         SELECT d.asset_id, d.asset_name, d.dependent_asset_id, d.dependency
         FROM bedrock.dependency_view d
@@ -111,6 +113,7 @@ async function readExpandedRelations(db, idList) {
     SELECT asset_id, asset_name, dependent_asset_id, dependency 
     FROM bedrock.dependency_view
     WHERE asset_id = ANY($1)
+    AND relation_type = 'PULLS_FROM'
     UNION
     SELECT d.asset_id, d.asset_name, d.dependent_asset_id, d.dependency
     FROM bedrock.dependency_view d
@@ -163,6 +166,7 @@ LEFT JOIN bedrock.run_groups r2 ON e2.run_group_id = r2.run_group_id
         SELECT asset_id, asset_name, dependent_asset_id, dependency 
         FROM bedrock.dependency_view
         WHERE dependent_asset_id = ANY($1)
+        AND relation_type = 'PULLS_FROM'
         UNION
         SELECT d.asset_id, d.asset_name, d.dependent_asset_id, d.dependency
         FROM bedrock.dependency_view d

--- a/src/api/lambdas/bedrock-api-backend/assets/getRelations.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/getRelations.js
@@ -33,6 +33,7 @@ async function readRelations(db, idValue) {
     SELECT asset_id, asset_name, dependent_asset_id, dependency 
     FROM bedrock.dependency_view
     WHERE asset_id = $1
+    AND relation_type = 'PULLS_FROM'
     UNION
     SELECT d.asset_id, d.asset_name, d.dependent_asset_id, d.dependency
     FROM bedrock.dependency_view d
@@ -86,6 +87,7 @@ LEFT JOIN bedrock.run_groups r2 ON e2.run_group_id = r2.run_group_id
         SELECT asset_id, asset_name, dependent_asset_id, dependency 
         FROM bedrock.dependency_view
         WHERE dependent_asset_id = $1
+        AND relation_type = 'PULLS_FROM'
         UNION
         SELECT d.asset_id, d.asset_name, d.dependent_asset_id, d.dependency
         FROM bedrock.dependency_view d


### PR DESCRIPTION
The relations endpoints that feed the frontend trees now only return "PULLS_FROM" relations/dependencies. 