### PR TITLE
Changing asset_id to primary key in etl table

### DIFF
--- a/src/db/bedrock-db/createNewBedrockDB.sql
+++ b/src/db/bedrock-db/createNewBedrockDB.sql
@@ -172,7 +172,7 @@ CREATE TABLE bedrock.etl (
 	run_group_id text NOT NULL,
 	active bool NOT NULL,
 	CONSTRAINT etl_key UNIQUE (asset_id, run_group_id),
-	CONSTRAINT etl_unique UNIQUE (asset_id)
+  CONSTRAINT etl_pk PRIMARY KEY (asset_id);
 );
 --
 ALTER TABLE bedrock.etl OWNER TO ${process.env.BEDROCK_DB_USER};


### PR DESCRIPTION
The problem we encountered with updating tasks yesterday was due to the asset_id not having a unique constraint. This was actually already fixed in the code and dev database, but the change hadn't been made in the prod database table. When chatting with Jon, he suggested making asset_id the primary key, which I thought made sense as well, so I've updated the tables and changed the database creation code here.