### PR TITLE
Name returned on successful deletion and bug fixed with executing tasks

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  checkExistence, deleteInfo, checkBeforeDelete
+  checkExistence, deleteInfo, checkBeforeDelete, getName
 } from '../utilities/utilities.js';
 
 async function deleteAssetType(
@@ -16,10 +16,10 @@ async function deleteAssetType(
   const assetsTableName = 'bedrock.assets';
   const connectedData = 'assets';
   const connectedDataIdField = 'asset_id'
+  const nameField = 'asset_type_name'
 
   const response = {
     statusCode: 200,
-    message: `Successfully deleted ${name} ${idValue}`,
     result: null,
   };
 
@@ -28,6 +28,8 @@ async function deleteAssetType(
   client = await db.newClient();
   await checkExistence(client, tableName, idField, idValue, name, shouldExist);
   await checkBeforeDelete(client, name, assetsTableName, idField, idValue, connectedData, connectedDataIdField)
+  let assetTypeName = await getName(db, nameField, tableName, idField, idValue)
+  response.message = `Successfully deleted ${name} ${assetTypeName}`,
   await client.query('BEGIN');
   await deleteInfo(client, tableName, idField, idValue, name);
   await deleteInfo(client, tableNameCustomFields, 'asset_type_id', idValue, name);

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  checkExistence, deleteInfo,
+  checkExistence, deleteInfo, getName
 } from '../utilities/utilities.js';
 
 async function deleteCustomField(
@@ -15,14 +15,16 @@ async function deleteCustomField(
   // We're only deleting the relationships between CFs and asset_types, not the actual CFs. 
   // which is why we're using a different table name.
   const linkingTableName = 'bedrock.asset_type_custom_fields'
+  const nameField = 'custom_field_name'
 
   const response = {
     statusCode: 200,
-    message: `Successfully deleted relationship between ${name} ${idValue} and corresponding asset_type(s).`,
     result: null,
   };
 
   await checkExistence(db, tableName, idField, idValue, name, shouldExist);
+  let customFieldName = await getName(db, nameField, tableName, idField, idValue)
+  response.message = `Successfully deleted relationship between ${name} ${customFieldName} and corresponding asset_type(s).`,
   await deleteInfo(db, linkingTableName, idField, idValue, name);
 
   return response;

--- a/src/api/lambdas/bedrock-api-backend/handler.js
+++ b/src/api/lambdas/bedrock-api-backend/handler.js
@@ -146,8 +146,7 @@ export async function lambda_handler(event) {
   let bodyJSON = {};
   if (api_result.result) {
     bodyJSON = api_result.result;
-  }
-  if (api_result.message) {
+  } else if (api_result.message) {
     bodyJSON.message = api_result.message.message || api_result.message;
   }
   let retvalue = {

--- a/src/api/lambdas/bedrock-api-backend/handler.js
+++ b/src/api/lambdas/bedrock-api-backend/handler.js
@@ -144,10 +144,10 @@ export async function lambda_handler(event) {
       break;
   }
   let bodyJSON = {};
-  if (api_result.result) {
-    bodyJSON = api_result.result;
-  } else if (api_result.message) {
+  if (api_result.message) {
     bodyJSON.message = api_result.message.message || api_result.message;
+  } else if (api_result.result) {
+    bodyJSON = api_result.result;
   }
   let retvalue = {
     statusCode: api_result.statusCode,

--- a/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  checkExistence, deleteInfo, checkBeforeDelete,
+  checkExistence, deleteInfo, checkBeforeDelete, getName
 } from '../utilities/utilities.js';
 
 async function deleteOwner(
@@ -14,16 +14,19 @@ async function deleteOwner(
   const shouldExist = true;
   const assetsTableName = 'bedrock.assets';
   const connectedData = 'assets';
-  const connectedDataIdField = 'asset_id'
+  const connectedDataIdField = 'asset_id';
+  const nameField = 'owner_name';
 
   const response = {
     statusCode: 200,
-    message: `Successfully deleted ${name} ${idValue}`,
     result: null,
   };
 
   await checkExistence(db, tableName, idField, idValue, name, shouldExist);
   await checkBeforeDelete(db, name, assetsTableName, idField, idValue, connectedData, connectedDataIdField)
+  let ownerName = await getName(db, nameField, tableName, idField, idValue)
+  response.message = `Successfully deleted ${name} ${ownerName}`,
+
   await deleteInfo(db, tableName, idField, idValue, name);
 
   return response;

--- a/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  checkExistence, deleteInfo, checkBeforeDelete,
+  checkExistence, deleteInfo, checkBeforeDelete, getName
 } from '../utilities/utilities.js';
 
 async function deleteRunGroup(
@@ -15,15 +15,17 @@ async function deleteRunGroup(
   const etlTableName = 'bedrock.etl'
   const connectedData = 'assets'
   const connectedDataIdField = 'asset_id'
+  const nameField = 'run_group_name'
 
   const response = {
     statusCode: 200,
-    message: `Successfully deleted ${name} ${idValue}`,
     result: null,
   };
 
   await checkExistence(db, tableName, idField, idValue, name, shouldExist);
   await checkBeforeDelete(db, name, etlTableName, idField, idValue, connectedData, connectedDataIdField)
+  let runGroupName = await getName(db, nameField, tableName, idField, idValue)
+  response.message = `Successfully deleted ${name} ${runGroupName}`,
   await deleteInfo(db, tableName, idField, idValue, name);
 
   return response;

--- a/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
 import {
-  checkExistence, deleteInfo,
+  checkExistence, deleteInfo, getName
 } from '../utilities/utilities.js';
 
 async function deleteTag(
@@ -13,17 +13,18 @@ async function deleteTag(
 ) {
   const shouldExist = true;
   const linkingTableName = 'bedrock.asset_tags'
+  const nameField = 'tag_name'
 
   const response = {
     statusCode: 200,
-    message: `Successfully deleted ${name} ${idValue}`,
     result: null,
   };
 
   await checkExistence(db, tableName, idField, idValue, name, shouldExist);
+  let tagName = await getName(db, nameField, tableName, idField, idValue)
+  response.message = `Successfully deleted ${name} ${tagName}`;
   await deleteInfo(db, tableName, idField, idValue, name);
   await deleteInfo(db, linkingTableName, idField, idValue, name);
-
   return response;
 }
 

--- a/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/utilities.js
@@ -229,6 +229,20 @@ async function checkBeforeDelete(db, name, tableName, idField, idValue, connecte
 
 }
 
+async function getName(db, nameField, tableName, idField, idValue) {
+  const sql = `SELECT ${nameField} FROM ${tableName} where ${idField} like $1`;
+  let res;
+  try {
+    res = await db.query(sql, [idValue]);
+  } catch (error) {
+    throw new Error([`Postgres error: ${error}`]);
+  }
+
+  let individualName = Object.values(res.rows[0])[0]
+  console.log(individualName)
+  return(individualName);
+}
+
 export {
   checkInfo,
   checkExistence,
@@ -241,4 +255,5 @@ export {
   addAssetTypeCustomFields,
   getBaseCustomFieldsInfo,
   checkBeforeDelete,
+  getName
 };


### PR DESCRIPTION
Two changes:

The deletion message, upon successful deletion, now gives the name instead of the id for all endpoints.

In handler.js, the message is now prioritized over the result. If there's a message, the API returns it, otherwise it returns the result. There was no "else" clause before, which resulted in an internal server area when the handler file set the bodyJSON  variavle to the result string, then tried to set a property of that string to the message string.