### PR TITLE
Endpoints now return lists in alphabetical order

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
@@ -11,12 +11,12 @@ async function deleteAssetType(
   name,
   tableName,
   tableNameCustomFields,
+  nameField
 ) {
   const shouldExist = true;
   const assetsTableName = 'bedrock.assets';
   const connectedData = 'assets';
   const connectedDataIdField = 'asset_id'
-  const nameField = 'asset_type_name'
 
   const response = {
     statusCode: 200,

--- a/src/api/lambdas/bedrock-api-backend/asset_types/getAssetTypeList.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/getAssetTypeList.js
@@ -14,6 +14,7 @@ async function getAssetTypeList(
   name,
   tableName,
   tableNameCustomFields,
+  nameField
 ) {
   let total;
   let res;
@@ -35,7 +36,7 @@ async function getAssetTypeList(
     return response;
   }
   response.result.total = total;
-  res = await getListInfo(offset, count, whereClause, db, idField, tableName, name);
+  res = await getListInfo(offset, count, whereClause, db, tableName, name, nameField);
   response.result.items = res.rows;
   response.result.url = buildURL(queryParams, domainName, res, offset, total, pathElements);
 

--- a/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
@@ -30,6 +30,8 @@ async function handleAssetTypes(
   const requiredFields = ['asset_type_id', 'asset_type_name'];
   const allFields = ['asset_type_id', 'asset_type_name', 'parent'];
   const tableNameCustomFields = 'bedrock.asset_type_custom_fields';
+  const nameField = 'asset_type_name'
+
 
   if (nParams === 2 && (pathElements[1] === null || pathElements[1].length === 0)) nParams = 1;
   if ('body' in event) {
@@ -55,6 +57,7 @@ async function handleAssetTypes(
             name,
             tableName,
             tableNameCustomFields,
+            nameField
           );
           break;
 
@@ -114,6 +117,7 @@ async function handleAssetTypes(
             name,
             tableName,
             tableNameCustomFields,
+            nameField
           );
           break;
 

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/extensions */
 /* eslint-disable no-console */
-import { checkExistence, deleteInfo } from '../utilities/utilities.js';
+import { checkExistence, deleteInfo, getName } from '../utilities/utilities.js';
 
 async function handleDelete(tableNames, client, idField, idValue, name) {
   try {
@@ -67,6 +67,7 @@ async function deleteAsset(
   idValue,
   name,
   tableName,
+  nameField
 ) {
   const shouldExist = true;
   const tableNames = ['bedrock.assets', 'bedrock.custom_values', 'bedrock.asset_tags', 'bedrock.tasks', 'bedrock.etl'];
@@ -76,7 +77,6 @@ async function deleteAsset(
 
   const response = {
     statusCode: 200,
-    message: `Successfully deleted asset ${name}`,
   };
 
   await checkExistence(db, tableName, idField, idValue, name, shouldExist);
@@ -85,6 +85,7 @@ async function deleteAsset(
 
   client = await db.newClient();
   await client.query('BEGIN');
+
   let ancestors = await getRelationsInfo(client, 'asset_id', idValue, name, 'bedrock.dependencies', 'dependent_asset_id');
   let descendants = await getRelationsInfo(client, 'dependent_asset_id', idValue, name, 'bedrock.dependencies', 'asset_id');
 
@@ -92,20 +93,23 @@ async function deleteAsset(
   if (ancestors) {
     if (!response.result) response.result = {}
     response.result.ancestors = formatAncestors(ancestors);
-    deleteInfo(client, 'bedrock.dependencies', 'asset_id', idValue, name)
+    await deleteInfo(client, 'bedrock.dependencies', 'asset_id', idValue, name)
   }
 
   if (descendants) {
     if (!response.result) response.result = {}
     response.result.descendants = formatDescendants(descendants);
     // if there are descendents, we must delete from the dependent_asset_id column in the dependencies table as well.
-    deleteInfo(client, 'bedrock.dependencies', 'dependent_asset_id', idValue, name)
+    await deleteInfo(client, 'bedrock.dependencies', 'dependent_asset_id', idValue, name)
   }
 
-  handleDelete(tableNames, client, idField, idValue, name);
+  let assetName = await getName(db, nameField, tableName, idField, idValue)
+  await handleDelete(tableNames, client, idField, idValue, name);
 
   if (descendants || ancestors) {
-    response.result.message = `Asset ${name} successfully deleted. The following relationships have been removed from the dependencies table.`
+    response.result.message = `Asset ${assetName} successfully deleted. The following relationships have been removed from the dependencies table.`
+  } else {
+    response.result.message = `Asset ${assetName} successfully deleted.`
   }
 
   await client.query('COMMIT');

--- a/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
@@ -25,6 +25,7 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
   let idValue;
   const name = 'asset';
   const tableName = 'bedrock.assets';
+  const nameField = 'asset_name'
   const requiredFields = ['asset_id', 'asset_name', 'description', 'location', 'active'];
   const allFields = ['asset_id', 'asset_name', 'description', 'location', 'active', 'asset_type_id', 'connection_class', 'location', 'link', 'owner_id', 'tags', 'notes', 'parents', 'custom_fields'];
 
@@ -104,6 +105,7 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
             idValue,
             name,
             tableName,
+            nameField
           );
           break;
 

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/deleteCustomField.js
@@ -10,12 +10,12 @@ async function deleteCustomField(
   idValue,
   name,
   tableName,
+  nameField
 ) {
   const shouldExist = true;
   // We're only deleting the relationships between CFs and asset_types, not the actual CFs. 
   // which is why we're using a different table name.
   const linkingTableName = 'bedrock.asset_type_custom_fields'
-  const nameField = 'custom_field_name'
 
   const response = {
     statusCode: 200,

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomFieldList.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/getCustomFieldList.js
@@ -12,6 +12,7 @@ async function getCustomFieldList(
   idField,
   name,
   tableName,
+  nameField
 ) {
   let total;
   let res;
@@ -38,7 +39,7 @@ async function getCustomFieldList(
     response.result = Object.fromEntries(tagList.entries());
     return response;
   }
-  res = await getListInfo(offset, count, whereClause, db, idField, tableName, name);
+  res = await getListInfo(offset, count, whereClause, db, tableName, name, nameField);
   tagList.set('items', res.rows);
   tagList.set('url', buildURL(queryParams, domainName, res, offset, total, pathElements));
   response.result = Object.fromEntries(tagList.entries());

--- a/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
+++ b/src/api/lambdas/bedrock-api-backend/custom_fields/handleCustomFields.js
@@ -24,6 +24,7 @@ async function handleCustomFields(
   let idValue;
   const name = 'custom_field';
   const tableName = 'bedrock.custom_fields';
+  const nameField = 'custom_field_name'
   const requiredFields = ['custom_field_id', 'custom_field_name', 'field_type', 'field_data'];
   const allFields = ['custom_field_id', 'custom_field_name', 'field_type', 'field_data'];
 
@@ -50,6 +51,7 @@ async function handleCustomFields(
             idField,
             name,
             tableName,
+            nameField
           );
           break;
 
@@ -104,6 +106,7 @@ async function handleCustomFields(
             idValue,
             name,
             tableName,
+            nameField
           );
           break;
 

--- a/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/deleteOwner.js
@@ -10,12 +10,12 @@ async function deleteOwner(
   idValue,
   name,
   tableName,
+  nameField
 ) {
   const shouldExist = true;
   const assetsTableName = 'bedrock.assets';
   const connectedData = 'assets';
   const connectedDataIdField = 'asset_id';
-  const nameField = 'owner_name';
 
   const response = {
     statusCode: 200,

--- a/src/api/lambdas/bedrock-api-backend/owners/getOwnerList.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/getOwnerList.js
@@ -12,6 +12,7 @@ async function getOwnerList(
   idField,
   name,
   tableName,
+  nameField
 ) {
   let total;
   let res;
@@ -38,7 +39,7 @@ async function getOwnerList(
     response.result = Object.fromEntries(ownerList.entries());
     return response;
   }
-  res = await getListInfo(offset, count, whereClause, db, idField, tableName, name);
+  res = await getListInfo(offset, count, whereClause, db, tableName, name, nameField);
   ownerList.set('items', res.rows);
   ownerList.set('url', buildURL(queryParams, domainName, res, offset, total, pathElements));
   response.result = Object.fromEntries(ownerList.entries());

--- a/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
+++ b/src/api/lambdas/bedrock-api-backend/owners/handleOwner.js
@@ -24,6 +24,7 @@ async function handleOwners(
   let idValue;
   const name = 'owner';
   const tableName = 'bedrock.owners';
+  const nameField = 'owner_name';
   const requiredFields = ['owner_id', 'owner_name', 'owner_email'];
   const allFields = ['owner_id', 'owner_name', 'owner_email', 'owner_phone', 'organization', 'department', 'division', 'notes'];
 
@@ -48,6 +49,7 @@ async function handleOwners(
             idField,
             name,
             tableName,
+            nameField
           );
           break;
 
@@ -101,6 +103,7 @@ async function handleOwners(
             idValue,
             name,
             tableName,
+            nameField
           );
           break;
 

--- a/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/deleteRunGroup.js
@@ -10,12 +10,12 @@ async function deleteRunGroup(
   idValue,
   name,
   tableName,
+  nameField
 ) {
   const shouldExist = true;
   const etlTableName = 'bedrock.etl'
   const connectedData = 'assets'
   const connectedDataIdField = 'asset_id'
-  const nameField = 'run_group_name'
 
   const response = {
     statusCode: 200,

--- a/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroupList.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/getRunGroupList.js
@@ -12,6 +12,7 @@ async function getRunGroupList(
   idField,
   name,
   tableName,
+  nameField
 ) {
   const runGroupList = new Map();
   // setting items first makes the order of the properties in the final object better
@@ -36,7 +37,7 @@ async function getRunGroupList(
     response.result = Object.fromEntries(runGroupList.entries());
     return response;
   }
-  let res = await getListInfo(offset, count, whereClause, db, idField, tableName, name);
+  let res = await getListInfo(offset, count, whereClause, db, tableName, name, nameField);
   runGroupList.set('items', res.rows);
   runGroupList.set('url', buildURL(queryParams, domainName, res, offset, total, pathElements));
   response.result = Object.fromEntries(runGroupList.entries());

--- a/src/api/lambdas/bedrock-api-backend/run_groups/handleRunGroups.js
+++ b/src/api/lambdas/bedrock-api-backend/run_groups/handleRunGroups.js
@@ -25,6 +25,7 @@ async function handleRunGroups(
   let idValue;
   const name = 'run_group';
   const tableName = 'bedrock.run_groups';
+  const nameField = 'run_group_name';
   const requiredFields = ['run_group_id', 'run_group_name', 'cron_string'];
   const allFields = ['run_group_id', 'run_group_name', 'cron_string'];
 
@@ -52,6 +53,7 @@ async function handleRunGroups(
             idField,
             name,
             tableName,
+            nameField
           );
           break;
 
@@ -106,6 +108,7 @@ async function handleRunGroups(
             idValue,
             name,
             tableName,
+            nameField
           );
           break;
 

--- a/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/deleteTag.js
@@ -10,10 +10,10 @@ async function deleteTag(
   idValue,
   name,
   tableName,
+  nameField
 ) {
   const shouldExist = true;
   const linkingTableName = 'bedrock.asset_tags'
-  const nameField = 'tag_name'
 
   const response = {
     statusCode: 200,

--- a/src/api/lambdas/bedrock-api-backend/tags/getTagList.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/getTagList.js
@@ -12,6 +12,7 @@ async function getTagList(
   idField,
   name,
   tableName,
+  nameField
 ) {
   let total;
   let res;
@@ -38,7 +39,7 @@ async function getTagList(
     response.result = Object.fromEntries(tagList.entries());
     return response;
   }
-  res = await getListInfo(offset, count, whereClause, db, idField, tableName, name);
+  res = await getListInfo(offset, count, whereClause, db, tableName, name, nameField);
   tagList.set('items', res.rows);
   tagList.set('url', buildURL(queryParams, domainName, res, offset, total, pathElements));
   response.result = Object.fromEntries(tagList.entries());

--- a/src/api/lambdas/bedrock-api-backend/tags/handleTags.js
+++ b/src/api/lambdas/bedrock-api-backend/tags/handleTags.js
@@ -24,6 +24,7 @@ async function handleTags(
   let idValue;
   const name = 'tag';
   const tableName = 'bedrock.tags';
+  const nameField = 'tag_name'
   const requiredFields = ['tag_id', 'tag_name', 'display_name'];
   const allFields = ['tag_id', 'tag_name', 'display_name'];
 
@@ -50,6 +51,7 @@ async function handleTags(
             idField,
             name,
             tableName,
+            nameField
           );
           break;
 
@@ -103,6 +105,7 @@ async function handleTags(
             idValue,
             name,
             tableName,
+            nameField
           );
           break;
 

--- a/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/listUtilities.js
@@ -51,9 +51,9 @@ async function getCount(whereClause, db, tableName, name) {
   return Number(res.rows[0].count);
 }
 
-async function getListInfo(offset, count, whereClause, db, idField, tableName, name) {
+async function getListInfo(offset, count, whereClause, db, tableName, name, nameField) {
   let sql = `SELECT * FROM ${tableName} ${whereClause.whereClause}`;
-  sql += ` order by ${idField} asc`;
+  sql += ` order by ${nameField} asc`;
   sql += ` offset ${offset} limit ${count} `;
   let res;
 


### PR DESCRIPTION
Endpoints now return lists in alphabetical order.

Both the "delete" file and the "getList" file for each endpoint need to know what column contains the name, so I moved initializing the nameField variable to the handle file in each folder, so in the future we only have to change it in one place if it changes.