### PR TITLE
table copy streams return correct error message

### DIFF
--- a/src/etl/lambdas/etl_task_table_copy/handler.js
+++ b/src/etl/lambdas/etl_task_table_copy/handler.js
@@ -71,13 +71,15 @@ export const lambda_handler = async function x(event, context) {
             return (err);
           }
         }))
-          .then(() => {
+          .then((err) => {
+            if (err) { resolve(returnError(err)); }
             pipeline(
               loc.source_location.stream,
               // streamDebug,
               loc.target_location.stream,
             )
-              .then(() => {
+              .then((err) => {
+                if (err) { resolve(returnError(err)); }
                 loc.source_location.promise
                   .then(() => {
                     loc.target_location.promise


### PR DESCRIPTION
Table Copy errors had been getting lost and overwritten with the useless message, 

_"The "body" argument must be of type function or an instance of Blob, ReadableStream, WritableStream, Stream, Iterable, AsyncIterable, or Promise or { readable, writable } pair. Received undefined'"._ 

This one has been bugging me for a long time. Finally took the time to figure it out.