### PR TITLE
Consistent use of double quotes in make_variables

### DIFF
--- a/src/api/api-gateways/bedrock-api/deploy/backend.tf
+++ b/src/api/api-gateways/bedrock-api/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/apis/bedrock-api/terraform.tfstate"
   }
 }

--- a/src/api/lambdas/bedrock-api-backend/deploy/backend.tf
+++ b/src/api/lambdas/bedrock-api-backend/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/bedrock-api-backend/terraform.tfstate"
   }
 }

--- a/src/api/lambdas/bedrock-api-backend/deploy/datablocks.tf
+++ b/src/api/lambdas/bedrock-api-backend/deploy/datablocks.tf
@@ -10,7 +10,7 @@ data "terraform_remote_state" "lambda_role" {
 data "terraform_remote_state" "bedrock_common_$$INSTANCE$$" {
   backend = "s3"
   config = {
-    bucket = $$statebucket$$
+    bucket = "$$statebucket$$"
     key    = "terraform/bedrock/$$INSTANCE$$/layers/common/terraform.tfstate"
     region = "us-east-1"
   }  
@@ -19,7 +19,7 @@ data "terraform_remote_state" "bedrock_common_$$INSTANCE$$" {
 data "terraform_remote_state" "bedrock_packages_$$INSTANCE$$" {
   backend = "s3"
   config = {
-    bucket = $$statebucket$$
+    bucket = "$$statebucket$$" 
     key    = "terraform/bedrock/$$INSTANCE$$/layers/packages/terraform.tfstate"
     region = "us-east-1"
   }

--- a/src/api/lambdas/bedrock-api-backend/makefile
+++ b/src/api/lambdas/bedrock-api-backend/makefile
@@ -17,7 +17,8 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../../make_variables
-	python3 ../../../scripts/vreplace.py -f ../../../make_variables $< $@
+	python3 ../../../scripts/vreplace.py -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) \
+		-v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) -f ../../../make_variables $< $@
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/api/lambdas/bedrock-api-backend/makefile
+++ b/src/api/lambdas/bedrock-api-backend/makefile
@@ -17,9 +17,7 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../../make_variables
-	python3 ../../../scripts/vreplace.py -v STATE_MACHINE_ARN=$(STATE_MACHINE_ARN) -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) \
-		-v BEDROCK_DB_USER=$(BEDROCK_DB_USER) -v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) -f ../../../make_variables $< $@
-
+	python3 ../../../scripts/vreplace.py -f ../../../make_variables $< $@
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/api/lambdas/bedrock-api-lambda-role/deploy/backend.tf
+++ b/src/api/lambdas/bedrock-api-lambda-role/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/roles/bedrock-api-lambda-role/terraform.tfstate"
   }
 }

--- a/src/bedrock_common/bedrock_common/deploy/backend.tf
+++ b/src/bedrock_common/bedrock_common/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$" 
     key    = "terraform/bedrock/$$INSTANCE$$/layers/common/terraform.tfstate"
   }
 }

--- a/src/bedrock_common/encrypt/deploy/backend.tf
+++ b/src/bedrock_common/encrypt/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key    = "terraform/bedrock/$$INSTANCE$$/layers/encrypt/terraform.tfstate"
   }
 }

--- a/src/bedrock_common/packages/deploy/backend.tf
+++ b/src/bedrock_common/packages/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key    = "terraform/bedrock/$$INSTANCE$$/layers/packages/terraform.tfstate"
   }
 }

--- a/src/bedrock_common/packages_py/deploy/backend.tf
+++ b/src/bedrock_common/packages_py/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key    = "terraform/bedrock/$$INSTANCE$$/layers/packages_py/terraform.tfstate"
   }
 }

--- a/src/bedrock_common/packages_py/deploy/makefile
+++ b/src/bedrock_common/packages_py/deploy/makefile
@@ -12,7 +12,7 @@ terraform.tfvars: ../../../make_variables
 
 layer.zip: ../requirements.txt
 	rm -Rf ./layer.zip ./package
-ifeq ($(build_mode),sam)
+ifeq ($(build_mode),"sam")
 	sam build --template-file template.yaml --use-container
 	pushd .aws-sam/build; zip -r9q ../../layer.zip ./python -x \*terraform\*; popd
 else

--- a/src/bedrock_common/packages_py/makefile
+++ b/src/bedrock_common/packages_py/makefile
@@ -13,7 +13,7 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../make_variables
-ifeq ($(build_mode),sam)
+ifeq ($(build_mode),"sam")
 	python3 ../../scripts/vreplace.py -v codeuri=.. -f ../../make_variables $< $@
 else
 	python3 ../../scripts/vreplace.py -v codeuri=. -f ../../make_variables $< $@

--- a/src/bedrock_common/table_copy/deploy/backend.tf
+++ b/src/bedrock_common/table_copy/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key    = "terraform/bedrock/$$INSTANCE$$/layers/table_copy/terraform.tfstate"
   }
 }

--- a/src/db/bedrock-db/deploy/backend.tf
+++ b/src/db/bedrock-db/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/testing/bedrock-db/terraform.tfstate"
   }
 }

--- a/src/db/bedrock-db/deploy/config.tf
+++ b/src/db/bedrock-db/deploy/config.tf
@@ -14,14 +14,14 @@ resource "aws_db_instance" "bedrock-db-$$INSTANCE$$" {
   parameter_group_name = "default.postgres13"
   skip_final_snapshot  = true
   publicly_accessible  = true
-  db_subnet_group_name = $$DB_SUBNET_GROUP_NAME$$
+  db_subnet_group_name = "$$DB_SUBNET_GROUP_NAME$$" 
   vpc_security_group_ids = [aws_security_group.bedrock-pg-sg-$$INSTANCE$$.id]
 }
 
 resource "aws_security_group" "bedrock-pg-sg-$$INSTANCE$$" {
   name        = "bedrock-pg-sg-$$INSTANCE$$"
   description = "Allow public access to postgres"
-  vpc_id      = $$BEDROCK_VPC_ID$$
+  vpc_id      = "$$BEDROCK_VPC_ID$$"
 
   ingress {
     description      = "Inbound access to postgres"

--- a/src/db/bedrock-db/makefile
+++ b/src/db/bedrock-db/makefile
@@ -32,7 +32,8 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../make_variables
-	python3 ../../scripts/vreplace.py -f ../../make_variables $< $@
+	python3 ../../scripts/vreplace.py -f -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) \
+		-v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) ../../make_variables $< $@
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/db/bedrock-db/makefile
+++ b/src/db/bedrock-db/makefile
@@ -32,8 +32,7 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../make_variables
-	python3 ../../scripts/vreplace.py -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) -v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) \
-		-v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) -f ../../make_variables $< $@
+	python3 ../../scripts/vreplace.py -f ../../make_variables $< $@
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/db/bedrock-db/makefile
+++ b/src/db/bedrock-db/makefile
@@ -32,8 +32,8 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../make_variables
-	python3 ../../scripts/vreplace.py -f -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) \
-		-v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) ../../make_variables $< $@
+	python3 ../../scripts/vreplace.py -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) \
+		-v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) -f ../../make_variables $< $@
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/etl/lambdas/bedrock-lambda-role/deploy/backend.tf
+++ b/src/etl/lambdas/bedrock-lambda-role/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/roles/bedrock-lambda-role/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/check_etl_job_task_status/deploy/backend.tf
+++ b/src/etl/lambdas/check_etl_job_task_status/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/check_etl_job_task_status/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/create_etl_run_map/deploy/backend.tf
+++ b/src/etl/lambdas/create_etl_run_map/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/create_etl_run_map/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/create_etl_run_map/makefile
+++ b/src/etl/lambdas/create_etl_run_map/makefile
@@ -18,7 +18,8 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../../make_variables
-	python3 ../../../scripts/vreplace.py -f ../../../make_variables $< $@ 
+	python3 ../../../scripts/vreplace.py  -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) \
+		-v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) -f ../../../make_variables $< $@ 
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/etl/lambdas/create_etl_run_map/makefile
+++ b/src/etl/lambdas/create_etl_run_map/makefile
@@ -18,8 +18,7 @@ prebuild:
 	mkdir -p ./build
 
 $(DEST_DIR)/%: $(SRC_DIR)/% ../../../make_variables
-	python3 ../../../scripts/vreplace.py -v BEDROCK_DB_HOST=$(BEDROCK_DB_HOST) -v BEDROCK_DB_USER=$(BEDROCK_DB_USER) \
-		-v BEDROCK_DB_PASSWORD=$(BEDROCK_DB_PASSWORD) -v BEDROCK_DB_NAME=$(BEDROCK_DB_NAME) -f ../../../make_variables $< $@
+	python3 ../../../scripts/vreplace.py -f ../../../make_variables $< $@ 
 
 init: prebuild $(TF_TARGS)
 	$(MAKE) -C build $(MAKECMDGOALS)

--- a/src/etl/lambdas/etl_email_results/deploy/backend.tf
+++ b/src/etl/lambdas/etl_email_results/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_email_results/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_email_results/deploy/config.tf
+++ b/src/etl/lambdas/etl_email_results/deploy/config.tf
@@ -23,8 +23,8 @@ resource "aws_lambda_function" "etl_email_results-$$INSTANCE$$" {
     }
     environment {
       variables = {
-          "EMAIL_RECIPIENT" = $$EMAIL_RECIPIENT$$
-          "EMAIL_SENDER"    = $$EMAIL_SENDER$$
+          "EMAIL_RECIPIENT" = "$$EMAIL_RECIPIENT$$"
+          "EMAIL_SENDER"    = "$$EMAIL_SENDER$$"
       }
     }
 }

--- a/src/etl/lambdas/etl_task_encrypt/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_encrypt/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_encrypt/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_task_file_copy/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_file_copy/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_file_copy/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_task_file_copy/localtest.json
+++ b/src/etl/lambdas/etl_task_file_copy/localtest.json
@@ -5,16 +5,11 @@
         "type": "file_copy",
         "active": true,
         "source_location": {
-          "path": "/",
-          "filename": "test.csv",
-          "connection": "A-2GKKZB3"
-        },
-        "target_location": {
           "path": "test/",
           "filename": "moo.csv",
           "connection": "s3_data_files"
         },
-        "target_location2": {
+        "target_location": {
           "path": "/PROD/person.errors/",
           "filename": "log.txt",
           "connection": "telestaff_ftp"

--- a/src/etl/lambdas/etl_task_run_lambda/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_run_lambda/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_run_lambda/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_task_sftp/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_sftp/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_sftp/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_task_sql/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_sql/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_sql/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_task_table_copy/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_table_copy/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_table_copy/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/etl_task_unknown/deploy/backend.tf
+++ b/src/etl/lambdas/etl_task_unknown/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/etl_task_unknown/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/setup_etl_job_task/deploy/backend.tf
+++ b/src/etl/lambdas/setup_etl_job_task/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/setup_etl_job_task/terraform.tfstate"
   }
 }

--- a/src/etl/lambdas/update_etl_run_map/deploy/backend.tf
+++ b/src/etl/lambdas/update_etl_run_map/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/lambdas/update_etl_run_map/terraform.tfstate"
   }
 }

--- a/src/etl/schedulers/bedrock-cron-scheduler/deploy/backend.tf
+++ b/src/etl/schedulers/bedrock-cron-scheduler/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/schedulers/bedrock_cron_scheduler/terraform.tfstate"
   }
 }

--- a/src/etl/schedulers/bedrock-eventbridge-role/deploy/backend.tf
+++ b/src/etl/schedulers/bedrock-eventbridge-role/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/roles/bedrock-eventbridge-role/terraform.tfstate"
   }
 }

--- a/src/etl/stepfunctions/bedrock-stepfunction-role/deploy/backend.tf
+++ b/src/etl/stepfunctions/bedrock-stepfunction-role/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/roles/bedrock-stepfunction-role/terraform.tfstate"
   }
 }

--- a/src/etl/stepfunctions/bedrock-stepfunction-role/deploy/config.tf
+++ b/src/etl/stepfunctions/bedrock-stepfunction-role/deploy/config.tf
@@ -19,7 +19,7 @@ resource "aws_iam_policy" "bedrock-stepfunction-policy-$$INSTANCE$$" {
   name        = "bedrock-stepfunction-policy-$$INSTANCE$$"
   description = "Policy for Bedrock step functions"
   policy = templatefile("./policy.json", {
-    account_num: $$account$$
+    account_num: "$$account$$" 
   })
 }
 

--- a/src/etl/stepfunctions/process_etl_run_group/deploy/backend.tf
+++ b/src/etl/stepfunctions/process_etl_run_group/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform { 
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/stepfunctions/process_etl_run_group/terraform.tfstate"
   }
 }

--- a/src/make_variables.sample
+++ b/src/make_variables.sample
@@ -1,10 +1,10 @@
 # Deploy settings.
-INSTANCE=<UNIQUE INSTANCE STRING LIKE ej-test-0: lowercase alphanumeric characters and hyphens only>
+INSTANCE="<UNIQUE INSTANCE STRING LIKE ej-test-0: lowercase alphanumeric characters and hyphens only>"
 region="us-east-1"
 statebucket="avl-tfstate-store"
-account=518970837364
-# Set build_mode to sam to build using SAM
-build_mode=std
+account="518970837364"
+# Set build_mode to "std", or "sam" to build using SAM
+build_mode="std"
 
 # The next four variables provide information on the VPC, subnets and security
 # groups that Bedrock will use. They can be created in the network folder and

--- a/src/network/deploy/backend.tf
+++ b/src/network/deploy/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
-    region = $$region$$
-    bucket = $$statebucket$$
+    region = "$$region$$"
+    bucket = "$$statebucket$$"
     key = "terraform/bedrock/$$INSTANCE$$/bedrock-network/terraform.tfstate"
   }
 }

--- a/src/scripts/vreplace.py
+++ b/src/scripts/vreplace.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
       for line in vfile.read().split('\n'):
         words = line.split('=')
         if (len(words) == 2):
-          vmap[words[0].strip()] = words[1].strip() # Just skip anything else
+          vmap[words[0].strip('" ')] = words[1].strip('" ') # Just skip anything else
 
   if args.variable is not None and len(args.variable) > 0:
     for vdef in args.variable:


### PR DESCRIPTION
The make_variables file has always been a combination of a shell script (no quotes for values) and a terraform file (double quotes for values.)

This makes everything work with double quoted values. The vreplace.py script takes them out when they are not required. 