### PR TITLE
Bug fix in delete asset

### DIFF
--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -77,6 +77,7 @@ async function deleteAsset(
 
   const response = {
     statusCode: 200,
+    result: {}
   };
 
   await checkExistence(db, tableName, idField, idValue, name, shouldExist);
@@ -86,18 +87,18 @@ async function deleteAsset(
   client = await db.newClient();
   await client.query('BEGIN');
 
+
   let ancestors = await getRelationsInfo(client, 'asset_id', idValue, name, 'bedrock.dependencies', 'dependent_asset_id');
   let descendants = await getRelationsInfo(client, 'dependent_asset_id', idValue, name, 'bedrock.dependencies', 'asset_id');
 
+
   // if either ancestors or descendants exists, we return info for them
   if (ancestors) {
-    if (!response.result) response.result = {}
     response.result.ancestors = formatAncestors(ancestors);
     await deleteInfo(client, 'bedrock.dependencies', 'asset_id', idValue, name)
   }
 
   if (descendants) {
-    if (!response.result) response.result = {}
     response.result.descendants = formatDescendants(descendants);
     // if there are descendents, we must delete from the dependent_asset_id column in the dependencies table as well.
     await deleteInfo(client, 'bedrock.dependencies', 'dependent_asset_id', idValue, name)


### PR DESCRIPTION
Fixed an itty bitty problem. Before, if an asset had no descendants or ancestors, response.result was never initialized, so
`response.result.message = `Asset ${assetName} successfully deleted.``
caused an error.

Through figuring this out, I noticed that after the api hit this error, the next request would return a 503 error. Most of the time the 503 did not occur however. I managed to track down what I think the issue is, but a solution will need a little more thought. Check out the proposed task 'Rethink error handling for api' on the asana page for more info.