### PR TITLE
fix noemail_list and email_list to handle array of objects

### DIFF
--- a/src/etl/lambdas/etl_email_results/sendEmails.js
+++ b/src/etl/lambdas/etl_email_results/sendEmails.js
@@ -8,8 +8,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url)); // current directory
 const compiledFunction = compileFile(join(__dirname, '/email.pug'));
 
 async function sendEmails(results) {
-  let noemail_list = results.noemail;
-  let email_list = results.success.concat(results.skipped).concat(results.failure.map(res => res.name));
+  let noemail_list = results.noemail.map(item => item.name);
+  let email_list = results.success.map(item => item.name)
+                          .concat(results.skipped.map(item => item.name))
+                          .concat(results.failure.map(item => item.name));
   let in_email_but_not_noemail = email_list.filter(item => !noemail_list.includes(item));
   if (in_email_but_not_noemail.length > 0) {
     let emailRecip = [process.env.EMAIL_RECIPIENT];


### PR DESCRIPTION
This addresses a fix to the "email on error" feature.  The noemail and success lists used to just be a list of asset names, but then were updated to a list of objects when the asset id was added.  The fix was to grab the asset name from each object before determining whether an email should be sent.