### PR TITLE
Fix for tag deletion bug

### DIFF
--- a/docs/docker-install.md
+++ b/docs/docker-install.md
@@ -15,13 +15,12 @@ After that you should be able to run docker commands in the terminal.
 
 ### Next Steps
 
-To build and run:
-make sure colima is running
+Make sure colima is running
 ```
 colima start
 ```
 
-The first time, you may have to run 
+The first time you run colima, you may have to run 
 ```
 docker context use colima
 ```
@@ -30,6 +29,7 @@ Bedrock will work on most Linux architectures, but we have standardized on Amazo
 
 Make_variables file: Use build_mode=std and the architecture of your host system.
 
+To build and run:
 ```
     docker build -f Dockerfile.bedrock --tag cityofasheville/bedrock .
     docker run -it -v .:/home/bedrock cityofasheville/bedrock bash

--- a/docs/docker-install.md
+++ b/docs/docker-install.md
@@ -1,10 +1,35 @@
+
+
 ## Installation on Docker
+
+### Getting started with Docker
+
+A simple way to install Docker on a Mac is using Homebrew.
+Colima (https://github.com/abiosoft/colima) is a minimal open source Docker runtime.
+
+- brew install docker
+- brew install colima
+- colima start
+
+After that you should be able to run docker commands in the terminal.
+
+### Next Steps
+
+To build and run:
+make sure colima is running
+```
+colima start
+```
+
+The first time, you may have to run 
+```
+docker context use colima
+```
 
 Bedrock will work on most Linux architectures, but we have standardized on Amazon Linux 2023, which can be run as a Docker container defined by [Dockerfile.bedrock](./Dockerfile.bedrock). This will install Python, Node, and AWS tools, as well as clone this repository.
 
 Make_variables file: Use build_mode=std and the architecture of your host system.
 
-To build and run:
 ```
     docker build -f Dockerfile.bedrock --tag cityofasheville/bedrock .
     docker run -it -v .:/home/bedrock cityofasheville/bedrock bash
@@ -25,13 +50,3 @@ Alternatively, you may set up a profile in the AWS credentials file (see documen
 
 Follow the build directions [here](./deploy-notes.md). 
 
-### Getting started with Docker
-
-A simple way to install Docker on a Mac is using Homebrew.
-Colima (https://github.com/abiosoft/colima) is a minimal open source Docker runtime.
-
-- brew install docker
-- brew install colima
-- colima start
-
-After that you should be able to run docker commands in the terminal.

--- a/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/addAssetType.js
@@ -13,7 +13,7 @@ function checkCustomFields(body) {
 }
 
 async function addAssetType(
-  db,
+  client,
   allFields,
   body,
   idField,
@@ -37,8 +37,6 @@ async function addAssetType(
 
   checkInfo(bodyWithID, requiredFields, name, idValue, idField);
   checkCustomFields(bodyWithID);
-
-  let client = await db.newClient();
 
   await client.query('BEGIN');
   await checkExistence(client, tableName, idField, idValue, name, shouldExist);

--- a/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/deleteAssetType.js
@@ -5,7 +5,7 @@ import {
 } from '../utilities/utilities.js';
 
 async function deleteAssetType(
-  db,
+  client,
   idField,
   idValue,
   name,
@@ -23,9 +23,6 @@ async function deleteAssetType(
     result: null,
   };
 
-  let client;
-
-  client = await db.newClient();
   await checkExistence(client, tableName, idField, idValue, name, shouldExist);
   await checkBeforeDelete(client, name, assetsTableName, idField, idValue, connectedData, connectedDataIdField)
   let assetTypeName = await getName(db, nameField, tableName, idField, idValue)

--- a/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/handleAssetTypes.js
@@ -16,6 +16,9 @@ async function handleAssetTypes(
   verb,
   db,
 ) {
+
+try{
+  let client = await db.newClient();
   let result = {
     statusCode: 200,
     message: '',
@@ -63,7 +66,7 @@ async function handleAssetTypes(
 
         case 'POST':
           result = await addAssetType(
-            db,
+            client,
             allFields,
             body,
             idField,
@@ -97,7 +100,7 @@ async function handleAssetTypes(
 
         case 'PUT':
           result = await updateAssetType(
-            db,
+            client,
             allFields,
             body,
             idField,
@@ -111,7 +114,7 @@ async function handleAssetTypes(
 
         case 'DELETE':
           result = await deleteAssetType(
-            db,
+            client,
             idField,
             idValue,
             name,
@@ -151,6 +154,13 @@ async function handleAssetTypes(
     console.log(result.message);
   }
   return result;
+} catch (e) {
+  if (['POST', 'PUT', 'DELETE'].includes(verb)) {
+    console.log("BINGO")
+    await client.query('ROLLBACK');
+    await client.release();
+    }
+}
 }
 
 export default handleAssetTypes;

--- a/src/api/lambdas/bedrock-api-backend/asset_types/updateAssetType.js
+++ b/src/api/lambdas/bedrock-api-backend/asset_types/updateAssetType.js
@@ -6,7 +6,7 @@ import {
 import { addAssetTypeCustomFields } from '../utilities/utilities.js'
 
 async function updateAssetType(
-  db,
+  client,
   allFields,
   body,
   idField,
@@ -24,7 +24,6 @@ async function updateAssetType(
     result: null,
   };
 
-  let client = await db.newClient();
   checkInfo(body, requiredFields, name, idValue, idField);
   await checkExistence(client, tableName, idField, idValue, name, shouldExist);
   await client.query('BEGIN');

--- a/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/addAsset.js
@@ -138,7 +138,7 @@ async function addTags(body, client) {
 }
 
 async function addAsset(
-  db,
+  client,
   idField,
   name,
   tableName,
@@ -164,7 +164,6 @@ async function addAsset(
     result: null,
   };
 
-  let client = await db.newClient();
   await client.query('BEGIN');
   await checkExistence(client, tableName, idField, idValue, name, shouldExist);
   checkInfo(bodyWithID, requiredFields, name, idValue, idField);
@@ -178,6 +177,8 @@ async function addAsset(
   let {parents, uses} = await addDependencies(bodyWithID, client);
   asset.set('parents', parents);
   asset.set('uses', uses);
+  throw new Error("ADD asset test error"
+  )
   asset.set('tags', await addTags(bodyWithID, client));
   await client.query('COMMIT');
   asset.set('asset_id', bodyWithID[idField]);

--- a/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/deleteAsset.js
@@ -62,7 +62,7 @@ function formatDescendants(descendants) {
 
 
 async function deleteAsset(
-  db,
+  client,
   idField,
   idValue,
   name,
@@ -80,17 +80,11 @@ async function deleteAsset(
     result: {}
   };
 
-  await checkExistence(db, tableName, idField, idValue, name, shouldExist);
-
-  let client;
-
-  client = await db.newClient();
+  await checkExistence(client, tableName, idField, idValue, name, shouldExist);
   await client.query('BEGIN');
-
 
   let ancestors = await getRelationsInfo(client, 'asset_id', idValue, name, 'bedrock.dependencies', 'dependent_asset_id');
   let descendants = await getRelationsInfo(client, 'dependent_asset_id', idValue, name, 'bedrock.dependencies', 'asset_id');
-
 
   // if either ancestors or descendants exists, we return info for them
   if (ancestors) {
@@ -104,7 +98,9 @@ async function deleteAsset(
     await deleteInfo(client, 'bedrock.dependencies', 'dependent_asset_id', idValue, name)
   }
 
-  let assetName = await getName(db, nameField, tableName, idField, idValue)
+  throw new Error("Delete asset test error")
+
+  let assetName = await getName(client, nameField, tableName, idField, idValue)
   await handleDelete(tableNames, client, idField, idValue, name);
 
   if (descendants || ancestors) {

--- a/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/handleAssets.js
@@ -12,6 +12,8 @@ import getExpandedRelations from './getExpandedRelations.js';
 
 // eslint-disable-next-line no-unused-vars
 async function handleAssets(event, pathElements, queryParams, verb, db) {
+  let client = await db.newClient();
+
   try {
   let response = {
     statusCode: 200,
@@ -55,7 +57,7 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
 
         case 'POST':
           response = await addAsset(
-            db,
+            client,
             idField,
             name,
             tableName,
@@ -87,7 +89,7 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
           response = await updateAsset(
             pathElements,
             queryParams,
-            db,
+            client,
             idField,
             idValue,
             name,
@@ -100,7 +102,7 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
 
         case 'DELETE':
           response = await deleteAsset(
-            db,
+            client,
             idField,
             idValue,
             name,
@@ -121,10 +123,10 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
     case 3:
       if (pathElements[2] === 'tasks') {
         if (verb === 'GET') {
-          response = await getTasks(db, idValue, idField, name);
+          response = await getTasks(client, idValue, idField, name);
         } else if (verb === 'PUT') {
           response = await updateTasks(
-            db,
+            client,
             idField,
             idValue,
             name,
@@ -195,6 +197,12 @@ async function handleAssets(event, pathElements, queryParams, verb, db) {
   }
   return response;
 } catch (e) {
+  console.log(e)
+    if (['POST', 'PUT', 'DELETE'].includes(verb)) {
+        console.log("BINGO")
+        await client.query('ROLLBACK');
+        await client.release();
+        }
   return {
     statusCode: 500,
     message: e,

--- a/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
@@ -3,11 +3,12 @@
 /* eslint-disable no-console */
 
 import {
-  getCustomFieldsInfo, addCustomFieldsInfo, getCustomValues, checkCustomFieldsInfo,
+  getCustomFieldsInfo,
+  addCustomFieldsInfo,
+  getCustomValues,
+  checkCustomFieldsInfo,
 } from '../utilities/assetUtilities.js';
-import {
-  checkInfo, updateInfo, deleteInfo,
-} from '../utilities/utilities.js';
+import { checkInfo, updateInfo, deleteInfo } from '../utilities/utilities.js';
 import getAsset from './getAsset.js';
 
 async function checkExistence(client, idValue) {
@@ -33,14 +34,14 @@ async function updateDependencies(client, idField, idValue, name, body) {
     throw new Error(`PG error deleting dependencies for update: ${error}`);
   }
   if (body.parents?.length > 0) {
-    console.log('parents')
+    console.log('parents');
     for (let i = 0; i < body.parents.length; i += 1) {
       const dependency = body.parents[i];
-      const relation_type = "PULLS_FROM";
+      const relation_type = 'PULLS_FROM';
       try {
         await client.query(
           'INSERT INTO bedrock.dependencies (asset_id, dependent_asset_id, relation_type) VALUES ($1, $2, $3)',
-          [idValue, dependency, relation_type],
+          [idValue, dependency, relation_type]
         );
       } catch (error) {
         throw new Error(`PG error updating dependencies: ${error}`);
@@ -48,14 +49,14 @@ async function updateDependencies(client, idField, idValue, name, body) {
     }
   }
   if (body.uses?.length > 0) {
-    console.log('uses')
+    console.log('uses');
     for (let i = 0; i < body.uses.length; i += 1) {
       const dependency = body.uses[i];
-      const relation_type = "USES";
+      const relation_type = 'USES';
       try {
         await client.query(
           'INSERT INTO bedrock.dependencies (asset_id, dependent_asset_id, relation_type) VALUES ($1, $2, $3)',
-          [idValue, dependency, relation_type],
+          [idValue, dependency, relation_type]
         );
       } catch (error) {
         throw new Error(`PG error updating dependencies: ${error}`);
@@ -66,8 +67,11 @@ async function updateDependencies(client, idField, idValue, name, body) {
 
 async function updateTags(idValue, idField, body, client, name) {
   // Finally, update any tags.
-  const tags = []; let tmpTags = [];
-  let sql; let res; let cnt;
+  const tags = [];
+  let tmpTags = [];
+  let sql;
+  let res;
+  let cnt;
   if (Array.isArray(body.tags)) {
     tmpTags = body.tags;
   } else {
@@ -81,8 +85,19 @@ async function updateTags(idValue, idField, body, client, name) {
     }
   }
 
-  // For now, just add any tags that aren't in the tags table
   if (tags.length > 0) {
+
+  }
+
+  // Now delete any existing tags
+  try {
+    await deleteInfo(client, 'bedrock.asset_tags', idField, idValue, name);
+  } catch (error) {
+    throw new Error(`PG error deleting tags for update: ${error}`);
+  }
+
+  if (tags.length > 0) {
+    // check to make sure all tags are valid
     sql = 'SELECT tag_id from bedrock.tags where tag_id in (';
     cnt = 1;
     for (let i = 0, comma = ''; i < tags.length; i += 1, comma = ', ', cnt += 1) {
@@ -91,25 +106,23 @@ async function updateTags(idValue, idField, body, client, name) {
     sql += ');';
     try {
       res = await client.query(sql, tags);
+      console.log(res);
     } catch (error) {
       throw new Error(`PG error reading tags for update: ${error}`);
     }
-  }
-    // Now delete any existing tags
-    try {
-      await deleteInfo(client, 'bedrock.asset_tags', idField, idValue, name);
-    } catch (error) {
-      throw new Error(`PG error deleting tags for update: ${error}`);
+
+    if (res.rows.length != tags.length) {
+      const rowTagIds = res.rows.map(row => row.tag_id);
+      const unmatchedTags = tags.filter(tag => !rowTagIds.includes(tag));
+      throw new Error(`Invalid tag IDs: ${unmatchedTags.join(', ')}`);
     }
 
-    // And add the new ones back in
-    if (tags.length > 0) {
+      // And add the new ones back in
     try {
-
       for (let i = 0; i < tags.length; i += 1) {
         res = await client.query(
           'INSERT INTO bedrock.asset_tags (asset_id, tag_id) VALUES ($1, $2)',
-          [body.asset_id, tags[i]],
+          [body.asset_id, tags[i]]
         );
       }
     } catch (error) {
@@ -123,18 +136,29 @@ async function updateTags(idValue, idField, body, client, name) {
 async function updateAsset(
   pathElements,
   queryParams,
-  db,
+  client,
   idField,
   idValue,
   name,
   tableName,
   requiredFields,
   allFields,
-  body,
+  body
 ) {
   let customFieldsFromAssetType;
   let customValues;
-  const baseFields = ['asset_id', 'asset_name', 'description', 'location', 'active', 'owner_id', 'asset_type_id', 'location', 'link', 'notes'];
+  const baseFields = [
+    'asset_id',
+    'asset_name',
+    'description',
+    'location',
+    'active',
+    'owner_id',
+    'asset_type_id',
+    'location',
+    'link',
+    'notes',
+  ];
   const assetType = body.asset_type_id;
   let customFields = new Map(Object.entries(body.custom_fields));
 
@@ -145,7 +169,6 @@ async function updateAsset(
   };
 
   checkInfo(body, requiredFields, name, idValue, idField);
-  let client = await db.newClient();
   await client.query('BEGIN');
   await checkExistence(client, idValue);
   await updateInfo(client, baseFields, body, tableName, idField, idValue, name);
@@ -165,12 +188,7 @@ async function updateAsset(
     await updateTags(idValue, idField, body, client, name);
   }
   await client.query('COMMIT');
-  const responseInfo = await getAsset(
-    queryParams,
-    db,
-    idValue,
-    allFields,
-  );
+  const responseInfo = await getAsset(queryParams, client, idValue, allFields);
   response.result = responseInfo.result;
   return response;
 }

--- a/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateAsset.js
@@ -94,7 +94,7 @@ async function updateTags(idValue, idField, body, client, name) {
     } catch (error) {
       throw new Error(`PG error reading tags for update: ${error}`);
     }
-
+  }
     // Now delete any existing tags
     try {
       await deleteInfo(client, 'bedrock.asset_tags', idField, idValue, name);
@@ -103,9 +103,10 @@ async function updateTags(idValue, idField, body, client, name) {
     }
 
     // And add the new ones back in
+    if (tags.length > 0) {
     try {
-      for (let i = 0; i < tags.length; i += 1) {
 
+      for (let i = 0; i < tags.length; i += 1) {
         res = await client.query(
           'INSERT INTO bedrock.asset_tags (asset_id, tag_id) VALUES ($1, $2)',
           [body.asset_id, tags[i]],
@@ -115,8 +116,8 @@ async function updateTags(idValue, idField, body, client, name) {
       throw new Error(`PG error inserting tags for update: ${error}`);
     }
   }
+
   return tags;
-  // End of adding any tags that aren't in the tags table for now
 }
 
 async function updateAsset(

--- a/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
+++ b/src/api/lambdas/bedrock-api-backend/assets/updateTasks.js
@@ -74,7 +74,7 @@ async function addTasks(client, allFields, body, idValue) {
 }
 
 async function updateTasks(
-  db,
+  client,
   idField,
   idValue,
   name,
@@ -93,7 +93,6 @@ async function updateTasks(
 
   checkInfo(body, requiredFields);
 
-  let client = await db.newClient();
   await client.query('BEGIN');
   // make sure asset exists in the asset table
   await checkExistence(client, 'bedrock.assets', idField, idValue, name, shouldExist);

--- a/src/api/lambdas/bedrock-api-backend/utilities/dbUtilities.js
+++ b/src/api/lambdas/bedrock-api-backend/utilities/dbUtilities.js
@@ -53,6 +53,7 @@ async function getDb(connection) {
     } catch (error) {
       throw (`PG connecting error: ${getErroMsg(error)}`);
     }
+  
     async function query(text, params) {
       try {
         const res = await _client.query(text, params);
@@ -61,14 +62,17 @@ async function getDb(connection) {
         }
         return res;
       } catch (error) {
-        await _client.query('ROLLBACK');
-        await _client.release();
         throw (`PG transaction error: ${getErroMsg(error)}`);
       }
     }
-
-    return { query };
+  
+    function release() {
+      return _client.release();
+    }
+  
+    return { query, release };
   }
+  
 
   return { query, newClient };
 


### PR DESCRIPTION
The API is set up to delete the tags, and replace them with the new given ones. However, the delete code was within a conditional (if tags.length >0), so it only triggered when there was one or more tags in the API request. If there were no tags in the API request, the code basically just didn't make any updates to the database, hence why we didn't see any pg errors.

Fixed by slitting up the conditional.