### PR TITLE
Fix minor glitches in network target files

### DIFF
--- a/src/network/deploy/makefile
+++ b/src/network/deploy/makefile
@@ -20,7 +20,7 @@ apply: terraform.tfvars $(config_files)
 	echo BEDROCK_VPC_ID=`terraform output -json BEDROCK_VPC_ID` >> ../bedrock_network_variables.generated
 	echo DB_SUBNET_GROUP_NAME=`terraform output -json DB_SUBNET_GROUP_NAME` >> ../bedrock_network_variables.generated
 	echo BEDROCK_SECURITY_GROUP_IDS=`terraform output -json BEDROCK_SECURITY_GROUP_IDS` >> ../bedrock_network_variables.generated
-	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` > ../bedrock_network_variables.generated
+	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` >> ../bedrock_network_variables.generated
 
 .PHONY: apply-y
 apply-y: terraform.tfvars $(config_files)
@@ -28,7 +28,7 @@ apply-y: terraform.tfvars $(config_files)
 	echo BEDROCK_VPC_ID=`terraform output -json BEDROCK_VPC_ID` >> ../bedrock_network_variables.generated
 	echo DB_SUBNET_GROUP_NAME=`terraform output -json DB_SUBNET_GROUP_NAME` >> ../bedrock_network_variables.generated
 	echo BEDROCK_SECURITY_GROUP_IDS=`terraform output -json BEDROCK_SECURITY_GROUP_IDS` >> ../bedrock_network_variables.generated
-	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` > ../bedrock_network_variables.generated
+	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` >> ../bedrock_network_variables.generated
 
 .PHONY: destroy itgoaway
 destroy: terraform.tfvars $(config_files)

--- a/src/network/makefile
+++ b/src/network/makefile
@@ -28,7 +28,7 @@ apply-y: $(TF_TARGS) $(dirs)
 destroy: $(dirs)
 
 clean:
-	rm -f *.instance
+	rm -f *.instance court_reminders_network_variables.generated
 	\rm -Rf build
 
 $(dirs):


### PR DESCRIPTION
I was building a new instance of Bedrock and discovered two minor glitches:

1. The makefile echoes the values of the network infrastructure created into the _court_reminders_network_variables.generated_ file, but the final echo accidentally truncated, so 3 of the 4 values are lost if the user doesn't capture them from the build.
2. Performing a 'make clean' fails to delete the generated _court_reminders_network_variables.generated_ file.

This pull request fixes those two issues.
