### PR TITLE
Fix minor glitches in network target files (#335)

### DIFF
--- a/src/network/deploy/makefile
+++ b/src/network/deploy/makefile
@@ -20,7 +20,7 @@ apply: terraform.tfvars $(config_files)
 	echo BEDROCK_VPC_ID=`terraform output -json BEDROCK_VPC_ID` >> ../bedrock_network_variables.generated
 	echo DB_SUBNET_GROUP_NAME=`terraform output -json DB_SUBNET_GROUP_NAME` >> ../bedrock_network_variables.generated
 	echo BEDROCK_SECURITY_GROUP_IDS=`terraform output -json BEDROCK_SECURITY_GROUP_IDS` >> ../bedrock_network_variables.generated
-	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` > ../bedrock_network_variables.generated
+	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` >> ../bedrock_network_variables.generated
 
 .PHONY: apply-y
 apply-y: terraform.tfvars $(config_files)
@@ -28,7 +28,7 @@ apply-y: terraform.tfvars $(config_files)
 	echo BEDROCK_VPC_ID=`terraform output -json BEDROCK_VPC_ID` >> ../bedrock_network_variables.generated
 	echo DB_SUBNET_GROUP_NAME=`terraform output -json DB_SUBNET_GROUP_NAME` >> ../bedrock_network_variables.generated
 	echo BEDROCK_SECURITY_GROUP_IDS=`terraform output -json BEDROCK_SECURITY_GROUP_IDS` >> ../bedrock_network_variables.generated
-	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` > ../bedrock_network_variables.generated
+	echo BEDROCK_PRIVATE_SUBNETS=`terraform output -json BEDROCK_PRIVATE_SUBNETS` >> ../bedrock_network_variables.generated
 
 .PHONY: destroy itgoaway
 destroy: terraform.tfvars $(config_files)

--- a/src/network/makefile
+++ b/src/network/makefile
@@ -28,7 +28,7 @@ apply-y: $(TF_TARGS) $(dirs)
 destroy: $(dirs)
 
 clean:
-	rm -f *.instance
+	rm -f *.instance court_reminders_network_variables.generated
 	\rm -Rf build
 
 $(dirs):


### PR DESCRIPTION
* Fix truncating echo of BEDROCK_PRIVATE_SUBNETS

The final echo in the makefile for building network resources has a single '>' and so accidentally truncates the file, losing the other values echoed into the file.

* Delete the court_reminders_network_variables.generated file as part of the clean target

Updated clean target to remove additional generated files.