### PR TITLE
Add BigQuery connector to table copy

### DIFF
--- a/src/bedrock_common/table_copy/package-lock.json
+++ b/src/bedrock_common/table_copy/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.431.0",
         "@aws-sdk/lib-storage": "^3.431.0",
+        "@google-cloud/bigquery": "^8.1.1",
         "csv-parse": "^5.5.2",
         "csv-stringify": "^6.4.4",
         "googleapis": "^127.0.0",
@@ -1181,6 +1182,181 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@google-cloud/bigquery": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/bigquery/-/bigquery-8.1.1.tgz",
+      "integrity": "sha512-2GHlohfA/VJffTvibMazMsZi6jPRx8MmaMberyDTL8rnhVs/frKSXVVRtLU83uSAy2j/5SD4mOs4jMQgJPON2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/common": "^6.0.0",
+        "@google-cloud/paginator": "^6.0.0",
+        "@google-cloud/precise-date": "^5.0.0",
+        "@google-cloud/promisify": "^5.0.0",
+        "arrify": "^3.0.0",
+        "big.js": "^6.2.2",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "stream-events": "^1.0.5",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-6.0.0.tgz",
+      "integrity": "sha512-IXh04DlkLMxWgYLIUYuHHKXKOUwPDzDgke1ykkkJPe48cGIS9kkL2U/o0pm4ankHLlvzLF/ma1eO86n/bkumIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "arrify": "^2.0.0",
+        "duplexify": "^4.1.3",
+        "extend": "^3.0.2",
+        "google-auth-library": "^10.0.0-rc.1",
+        "html-entities": "^2.5.2",
+        "retry-request": "^8.0.0",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/@google-cloud/promisify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.1.0.tgz",
+      "integrity": "sha512-G/FQx5cE/+DqBbOpA5jKsegGwdPniU6PuIEMt+qxWgFxvxuFOzVmp6zYchtYuwAWV5/8Dgs0yAmjvNZv3uXLQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gaxios": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
+      "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/google-auth-library": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.0.tgz",
+      "integrity": "sha512-CmIrSy1bqMQUsPmA9+hcSbAXL80cFhu40cGMUjCaLpNKVzzvi+0uAHq8GNZxkoGYIsTX4ZQ7e4aInAqWxgn4fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-6.0.0.tgz",
+      "integrity": "sha512-g5nmMnzC+94kBxOKkLGpK1ikvolTFCC3s2qtE4F+1EuArcJ7HHC23RDQVt3Ra3CqpUYZ+oXNKZ8n5Cn5yug8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-5.0.0.tgz",
+      "integrity": "sha512-9h0Gvw92EvPdE8AK8AgZPbMnH5ftDyPtKm7/KUfcJVaPEPjwGDsJd1QV0H8esBDV4II41R/2lDWH1epBqIoKUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-5.0.0.tgz",
+      "integrity": "sha512-N8qS6dlORGHwk7WjGXKOSsLjIjNINCPicsOX6gyyLiYk7mq3MtII96NZ9N2ahwA2vnkLmZODOIH9rlNniYWvCQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@js-joda/core": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-5.6.3.tgz",
@@ -1828,6 +2004,15 @@
       "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-0.5.0.tgz",
       "integrity": "sha512-7qSgZbincDDDFyRweCIEvZULFAw5iz/DeunhvuxpL31nfntX3P4Yd4HkHBRg9H8CdqY1e5WFN1PZIz/REL9MVQ=="
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.14.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
@@ -1872,6 +2057,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/arrify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1890,6 +2087,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
@@ -2003,6 +2213,15 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.0.tgz",
       "integrity": "sha512-edlXFVKcUx7r8Vx5zQucsuMg4wb/xT6qyz+Sr1vnLrdXqlLD1+UKyWNyZ9zn6mUW1ewmGxrpVwAcChGF0HQ/2Q=="
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
@@ -2043,12 +2262,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -2110,6 +2350,41 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/function-bind": {
@@ -2189,6 +2464,15 @@
         "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -2287,6 +2571,22 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -2542,6 +2842,26 @@
       "resolved": "https://registry.npmjs.org/native-duplexpair/-/native-duplexpair-1.0.0.tgz",
       "integrity": "sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA=="
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2760,6 +3080,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -2864,6 +3197,21 @@
         "readable-stream": "^3.5.0"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2876,6 +3224,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
     },
     "node_modules/tarn": {
       "version": "3.0.2",
@@ -2902,6 +3256,78 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.0.tgz",
+      "integrity": "sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/tr46": {
@@ -2939,6 +3365,15 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/src/bedrock_common/table_copy/package.json
+++ b/src/bedrock_common/table_copy/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.431.0",
     "@aws-sdk/lib-storage": "^3.431.0",
+    "@google-cloud/bigquery": "^8.1.1",
     "csv-parse": "^5.5.2",
     "csv-stringify": "^6.4.4",
     "googleapis": "^127.0.0",

--- a/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
+++ b/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
@@ -59,8 +59,8 @@ async function updateBqTableFromCsv(location, csvFilePath, append = false) {
   const writeDisposition = append ? 'WRITE_APPEND' : 'WRITE_TRUNCATE'; 
   const metadata = {
     sourceFormat: 'CSV',
-    skipLeadingRows: 1,
-    autodetect: true,
+    skipLeadingRows: 0,
+    maxBadRecords: 0,
     writeDisposition: writeDisposition, //'WRITE_APPEND' or 'WRITE_TRUNCATE'
   };
 
@@ -76,15 +76,16 @@ async function updateBqTableFromCsv(location, csvFilePath, append = false) {
       .table(location.tablename)
       .createLoadJob(csvFilePath, metadata);
 
-    // console.log(`Job ${job.id} started.`);
+    let state = 'RUNNING'
 
-    await job.get();
-    
-    const status = job.metadata.status;
-    if (status.errorResult) {
-      throw new Error(`BigQuery Job failed with error: ${JSON.stringify(status.errors)}`);
+    while (state === 'RUNNING') {  
+      await job.get();
+      const status = job.metadata.status;
+      state = status.state;
+      if (status.errorResult) {
+        throw new Error(`BigQuery Job failed with error: ${JSON.stringify(status.errors)}`);
+      }
     }
-
     console.log(`BigQuery Job ${job.id} completed successfully.`);
 
   } catch (error) {

--- a/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
+++ b/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
@@ -9,7 +9,7 @@ import { Writable } from 'stream';
 async function createBigQueryWritable(location) {
   const { promise, resolve, reject } = createPromise();
   let buff = '';
-  const folderPath = './tmp';
+  const folderPath = '/tmp';
   const tempFilePath = `${folderPath}/tmpStream.csv`;
   const append = location.append ?? false;
 

--- a/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
+++ b/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
@@ -33,7 +33,7 @@ async function createBigQueryWritable(location) {
         reject(err);
       } finally {
         if (tempFilePath && fs.existsSync(tempFilePath)) {
-          await fsp.rm(folderPath, { recursive: true, force: true });
+          await fsp.rm(tempFilePath, { recursive: true, force: true });
           console.log(`\nCleaned up temporary file: ${tempFilePath}`);
         }
       }

--- a/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
+++ b/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
@@ -1,0 +1,97 @@
+import fs from 'fs';
+import * as fsp from 'fs/promises';
+import { BigQuery } from '@google-cloud/bigquery';
+import { google } from 'googleapis';
+import { createPromise } from './promiseWithResolvers.js';
+import { Writable } from 'stream';
+
+
+async function createBigQueryWritable(location) {
+  const { promise, resolve, reject } = createPromise();
+  let buff = '';
+  const folderPath = './tmp';
+  const tempFilePath = `${folderPath}/tmpStream.csv`;
+  const append = location.append ?? false;
+
+  const csvStream = new Writable({
+    write(chunk, encoding, done) {
+      buff += chunk;
+      done();
+    },
+
+    async final(done) {
+      try {
+        await fsp.mkdir(folderPath, { recursive: true });
+        await fsp.writeFile(tempFilePath, buff);
+        console.log(`Successfully created CSV: ${tempFilePath}`);
+
+        await updateBqTableFromCsv(location, tempFilePath, append);
+
+        resolve(tempFilePath);
+      } catch (err) {
+        console.error('CSV error: ', err);
+        reject(err);
+      } finally {
+        if (tempFilePath && fs.existsSync(tempFilePath)) {
+          await fsp.rm(folderPath, { recursive: true, force: true });
+          console.log(`\nCleaned up temporary file: ${tempFilePath}`);
+        }
+      }
+      done();
+    },
+  });
+
+  return { stream: csvStream, promise };
+}
+
+async function updateBqTableFromCsv(location, csvFilePath, append = false) {
+  const jwtClient = new google.auth.JWT({
+    email: location.conn_info.client_email,
+    key: location.conn_info.private_key,
+    scopes: ['https://www.googleapis.com/auth/bigquery'],
+  });
+
+  const bigquery = new BigQuery({
+    projectId: location.conn_info.project_id,
+    authClient: jwtClient,
+  });
+
+  const writeDisposition = append ? 'WRITE_APPEND' : 'WRITE_TRUNCATE'; 
+  const metadata = {
+    sourceFormat: 'CSV',
+    skipLeadingRows: 1,
+    autodetect: true,
+    writeDisposition: writeDisposition, //'WRITE_APPEND' or 'WRITE_TRUNCATE'
+  };
+
+  console.log(`Starting update job for table ${location.datasetId}.${location.tableId}`);
+
+  try {
+    if (!fs.existsSync(csvFilePath)) {
+      throw new Error(`File not found at path: ${csvFilePath}`);
+    }
+
+    const [job] = await bigquery
+      .dataset(location.datasetId)
+      .table(location.tableId)
+      .createLoadJob(csvFilePath, metadata);
+
+    // console.log(`Job ${job.id} started.`);
+
+    await job.get();
+    
+    const status = job.metadata.status;
+    if (status.errorResult) {
+      throw new Error(`BigQuery Job failed with error: ${JSON.stringify(status.errors)}`);
+    }
+
+    console.log(`BigQuery Job ${job.id} completed successfully.`);
+
+  } catch (error) {
+    console.error('An error occurred during the bulk update process:');
+    console.error(error);
+    throw error;
+  }
+}
+
+export default createBigQueryWritable;

--- a/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
+++ b/src/etl/lambdas/etl_task_table_copy/createBigQueryWritable.js
@@ -64,7 +64,7 @@ async function updateBqTableFromCsv(location, csvFilePath, append = false) {
     writeDisposition: writeDisposition, //'WRITE_APPEND' or 'WRITE_TRUNCATE'
   };
 
-  console.log(`Starting update job for table ${location.datasetId}.${location.tableId}`);
+  console.log(`Starting update job for table ${location.schemaname}.${location.tablename}`);
 
   try {
     if (!fs.existsSync(csvFilePath)) {
@@ -72,8 +72,8 @@ async function updateBqTableFromCsv(location, csvFilePath, append = false) {
     }
 
     const [job] = await bigquery
-      .dataset(location.datasetId)
-      .table(location.tableId)
+      .dataset(location.schemaname)
+      .table(location.tablename)
       .createLoadJob(csvFilePath, metadata);
 
     // console.log(`Job ${job.id} started.`);

--- a/src/etl/lambdas/etl_task_table_copy/getBigQueryStream.js
+++ b/src/etl/lambdas/etl_task_table_copy/getBigQueryStream.js
@@ -27,8 +27,8 @@ async function getBigQueryStream(location) {
     let retStream;
     let bodyStream = new PassThrough();
     const tableHeaders = location.tableheaders ?? false;
-    const datasetId = location.datasetId;
-    const tableId = location.tableId;
+    const datasetId = location.schemaname;
+    const tableId = location.tablename;
     const data = bigquery.dataset(datasetId).table(tableId);
 
     const readableStream = data.createReadStream();

--- a/src/etl/lambdas/etl_task_table_copy/getBigQueryStream.js
+++ b/src/etl/lambdas/etl_task_table_copy/getBigQueryStream.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-console */
+import { google } from 'googleapis';
+import { BigQuery } from '@google-cloud/bigquery';
+import { PassThrough } from 'stream';
+import { stringify } from 'csv-stringify';
+import { createPromise } from './promiseWithResolvers.js';
+import createBigQueryWritable from './createBigQueryWritable.js';
+
+
+async function getBigQueryStream(location) {
+  const { promise, resolve, reject } = createPromise();
+  if (location.fromto === 'target_location') {
+    return createBigQueryWritable(location);
+  }
+  try {
+    const jwtClient = new google.auth.JWT({
+        email: location.conn_info.client_email,
+        key: location.conn_info.private_key,
+        scopes: ['https://www.googleapis.com/auth/bigquery'],
+      });
+
+    const bigquery = new BigQuery({
+      projectId: location.conn_info.project_id,
+      authClient: jwtClient,
+    });
+
+    let retStream;
+    let bodyStream = new PassThrough();
+    const tableHeaders = location.tableheaders ?? false;
+    const datasetId = location.datasetId;
+    const tableId = location.tableId;
+    const data = bigquery.dataset(datasetId).table(tableId);
+
+    const readableStream = data.createReadStream();
+
+    readableStream.on('end', () => {
+      resolve();
+    });
+
+    readableStream.on('error', (err) => {
+      reject(err);
+    });
+
+    bodyStream = readableStream
+      .pipe(stringify({ header: tableHeaders })
+    );
+
+    console.log(`Copy from BigQuery Table: ${datasetId}.${tableId}`);
+
+    if (location.tableheaders) {
+      retStream = bodyStream;
+    } else {
+      retStream = bodyStream;
+    }
+
+    return { stream: retStream, promise };
+  } catch (err) {
+    throw new Error(`BigQuery stream error ${err}`);
+  }
+} 
+
+export default getBigQueryStream;

--- a/src/etl/lambdas/etl_task_table_copy/handler.js
+++ b/src/etl/lambdas/etl_task_table_copy/handler.js
@@ -4,6 +4,7 @@ import getPgStream from './getPgStream.js';
 import getSsStream from './getSsStream.js';
 import getS3Stream from './getS3Stream.js';
 import getGoogleStream from './getGoogleStream.js';
+import getBigQueryStream from './getBigQueryStream.js';
 // eslint-disable-next-line no-unused-vars
 import streamDebug from './streamDebug.js';
 
@@ -55,6 +56,8 @@ export async function lambda_handler(event) {
             streamObject = await getGoogleStream(eachloc.location);
           } else if (eachloc.location.conn_info.type === 's3') {
             streamObject = await getS3Stream(eachloc.location);
+          } else if (eachloc.location.conn_info.type === 'bigquery') {
+            streamObject = await getBigQueryStream(eachloc.location);
           } else {
             return (returnError(`Invalid connection type: ${eachloc.location.conn_info.type}`));
           }

--- a/src/etl/lambdas/etl_task_table_copy/localtest2.json
+++ b/src/etl/lambdas/etl_task_table_copy/localtest2.json
@@ -1,0 +1,25 @@
+{
+  "ETLJob": {
+    "etl_tasks": [
+      {
+        "type": "table_copy",
+        "active": true,
+        "source_location": {
+          "datasetId": "aletizia_sbx",
+          "tableId": "google_info",
+          "connection": "big_query_testing"
+        },
+        "target_location": {
+          "asset": "bq_test.goog",
+          "tab": "Sheet1",
+          "range": "A2:E",
+          "filename": "bq test",
+          "connection": "bedrock-googlesheets",
+          "connection_id": "76085554183a536a7fae",
+          "spreadsheetid": "1VxwB9TK1woPSsi3TbaSRb1ptNAwRsjdXa_AxHTd84sU"
+        }
+      }
+    ]
+  },
+  "TaskIndex": 0
+}

--- a/src/etl/lambdas/etl_task_table_copy/localtest2.json
+++ b/src/etl/lambdas/etl_task_table_copy/localtest2.json
@@ -5,9 +5,9 @@
         "type": "table_copy",
         "active": true,
         "source_location": {
-          "datasetId": "aletizia_sbx",
-          "tableId": "google_info",
-          "connection": "big_query_testing"
+          "schemaname": "aletizia_sbx",
+          "tablename": "google_info",
+          "connection": "bedrock-bigquery"
         },
         "target_location": {
           "asset": "bq_test.goog",


### PR DESCRIPTION
## Description

Adds support for Google BigQuery as a data source and destination in the ETL table copy
Lambda.

## Changes

 - New getBigQueryStream.js — Handles BigQuery as a stream source (read) using Google OAuth 
JWT authentication and the BigQuery API. Also delegates to createBigQueryWritable when 
BigQuery is the target.
 - New createBigQueryWritable.js — Handles BigQuery as a stream destination (write) by 
buffering data into a temporary CSV at /tmp/tmpStream.csv, then uploading it to a BigQuery 
table. Supports append mode.
 - handler.js — Wired in getBigQueryStream as a new connection type (bigquery) alongside the 
existing pg, ss, s3, and google types.
 - package.json / package-lock.json — Added @google-cloud/bigquery and googleapis 
dependencies.

## Testing

 - Includes localtest2.json for local Lambda invocation testing.
