### PR TITLE
Pin paramiko to version 4.x and update OpenPGP config

### DIFF
--- a/src/bedrock_common/packages_py/requirements.txt
+++ b/src/bedrock_common/packages_py/requirements.txt
@@ -1,3 +1,3 @@
 boto3
-paramiko
+paramiko>=4.0,<5.0
 pysmb

--- a/src/etl/lambdas/etl_task_encrypt/handler.js
+++ b/src/etl/lambdas/etl_task_encrypt/handler.js
@@ -43,9 +43,13 @@ export const lambda_handler = async function x(event) {
     const encryptedStream = await encrypt({
       message: await createMessage({ binary: webStream }),
       encryptionKeys: publicKey,
-      config: { rejectPublicKeyAlgorithms: new Set([]) },
-      // Needed for Delta Dental, whose key is ElGamal,
-      // which OpenPGP won't encrypt by default cuz sux}
+      config: {
+        rejectPublicKeyAlgorithms: new Set([]),
+        // Needed for Delta Dental, whose key is ElGamal,
+        // which OpenPGP won't encrypt by default cuz sux
+        allowMissingKeyFlags: true,
+        // Needed for keys that have no key flags set in their packet
+      },
     });
 
     // put encrypted file 'encrypted_filename' to s3


### PR DESCRIPTION
- Pin paramiko to prevent issues from breaking changes in version 5.x 
- Add `allowMissingKeyFlags` to the OpenPGP configuration for better compatibility with certain keys.